### PR TITLE
Update JSONRenderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,92 @@ func main() {
 
 ![Vditor](https://b3logfile.com/file/2020/02/%E6%88%AA%E5%9B%BE%E4%B8%93%E7%94%A8-ef21ef12.png)
 
+- 关于`lute.JSONRenderer()`的使用
+
+```typescript
+// JSONRenderer的类型
+type JSONRendererType = Array<JSONRendererItemType>
+
+// Flag节点
+type FlagType = |
+    | "Paragraph"
+    | "Emphasis"
+    | "Strong"
+    | "Blockquote"
+    | "ListItem"
+    | "Strikethrough"
+    | "TableHead"
+    | "Table"
+    | "TableRow"
+    | "Mark"
+    | "Sub"
+    | "Sup"
+    | "Tag"
+    | "BlockRef"
+
+// 非Flag节点
+type NotFlagType = |
+    | "Heading"
+    | "ThematicBreak"
+    | "List"
+    | "HTMLBlock"
+    | "InlineHTML"
+    | "CodeBlock"
+    | "Text"
+    | "CodeSpan"
+    | "HardBreak"     
+    | "SoftBreak"
+    | "Link"
+    | "Image"
+    | "HTMLEntity"
+    | "TaskListItemMarker"
+    | "TableCell"
+    | "EmojiUnicode"
+    | "EmojiImg"
+    | "MathBlock"
+    | "InlineMath"
+    | "YamlFrontMatter"
+    | "Backslash"
+    | "BlockEmbed"
+    | "BlockQueryEmbed"
+
+interface JSONRendererItemType {
+    type?: string
+    value?: string
+    flag?: string
+    title?: string
+    language?: string
+    children?: Array<JSONRendererItemType>
+}
+
+// 节点分为四类：常规节点、flag节点、链接节点、代码块节点
+interface NormalNodeType {
+    type: string
+    value: string
+    children?: Array<JSONRendererItemType>
+}
+
+interface FlagNodeType {
+    flag: string
+    children?: Array<JSONRendererItemType>
+}
+
+// 链接或者图片
+interface LinkNodeType {
+    type: string
+    value: string
+    title: string
+    children?: Array<JSONRendererItemType>
+}
+
+interface CodeBlockType {
+    type: string
+    value: string
+    language: string
+    mindmap?: string // 如果language为mingmap
+}
+```
+
 一些细节：
 
 1. lute.js 没有内置语法高亮特性

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ func main() {
 
 ![Vditor](https://b3logfile.com/file/2020/02/%E6%88%AA%E5%9B%BE%E4%B8%93%E7%94%A8-ef21ef12.png)
 
-- 关于`lute.JSONRenderer()`的使用
+- 关于`lute.RenderJSON()`的使用
 
 ```typescript
 // JSONRenderer的类型
@@ -373,6 +373,7 @@ interface JSONRendererItemType {
     flag?: string
     title?: string
     language?: string
+    mindmap?: string
     children?: Array<JSONRendererItemType>
 }
 

--- a/README_en_US.md
+++ b/README_en_US.md
@@ -317,7 +317,7 @@ Some details:
 1. lute.js has no built-in syntax highlighting feature
 2. The size of lute.js after compilation is ~2MB, the size after compression through `brotli -o lute.min.js.br lute.min.js` is ~200KB, the size after regular GZip compression is ~300KB
 
-- How to use `lute.JSONRenderer()`
+- How to use `lute.RenderJSON()`
 
 ```typescript
 // Type of JSONRenderer
@@ -372,6 +372,7 @@ interface JSONRendererItemType {
     flag?: string
     title?: string
     language?: string
+    mindmap?: string
     children?: Array<JSONRendererItemType>
 }
 

--- a/README_en_US.md
+++ b/README_en_US.md
@@ -317,6 +317,92 @@ Some details:
 1. lute.js has no built-in syntax highlighting feature
 2. The size of lute.js after compilation is ~2MB, the size after compression through `brotli -o lute.min.js.br lute.min.js` is ~200KB, the size after regular GZip compression is ~300KB
 
+- How to use `lute.JSONRenderer()`
+
+```typescript
+// Type of JSONRenderer
+type JSONRendererType = Array<JSONRendererItemType>
+
+// Flag Node
+type FlagType = |
+    | "Paragraph"
+    | "Emphasis"
+    | "Strong"
+    | "Blockquote"
+    | "ListItem"
+    | "Strikethrough"
+    | "TableHead"
+    | "Table"
+    | "TableRow"
+    | "Mark"
+    | "Sub"
+    | "Sup"
+    | "Tag"
+    | "BlockRef"
+
+// Non-Flag Node
+type NotFlagType = |
+    | "Heading"
+    | "ThematicBreak"
+    | "List"
+    | "HTMLBlock"
+    | "InlineHTML"
+    | "CodeBlock"
+    | "Text"
+    | "CodeSpan"
+    | "HardBreak"     
+    | "SoftBreak"
+    | "Link"
+    | "Image"
+    | "HTMLEntity"
+    | "TaskListItemMarker"
+    | "TableCell"
+    | "EmojiUnicode"
+    | "EmojiImg"
+    | "MathBlock"
+    | "InlineMath"
+    | "YamlFrontMatter"
+    | "Backslash"
+    | "BlockEmbed"
+    | "BlockQueryEmbed"
+
+interface JSONRendererItemType {
+    type?: string
+    value?: string
+    flag?: string
+    title?: string
+    language?: string
+    children?: Array<JSONRendererItemType>
+}
+
+// Node has 4 types: Normal Node, Flag Node, Link Node, Codeblock Node
+interface NormalNodeType {
+    type: string
+    value: string
+    children?: Array<JSONRendererItemType>
+}
+
+interface FlagNodeType {
+    flag: string
+    children?: Array<JSONRendererItemType>
+}
+
+// Link or Image
+interface LinkNodeType {
+    type: string
+    value: string
+    title: string
+    children?: Array<JSONRendererItemType>
+}
+
+interface CodeBlockType {
+    type: string
+    value: string
+    language: string
+    mindmap?: string // if language is "mindmap"
+}
+```
+
 ## 📜 Documentation
 
 * [Interpretation of CommonMark specifications](https://ld246.com/article/1566893557720)

--- a/lute.go
+++ b/lute.go
@@ -166,6 +166,15 @@ func (lute *Lute) HTML2Text(dom string) string {
 	return tree.Root.Text()
 }
 
+// RenderJSON 用于渲染 JSON 格式数据
+func (lute *Lute) RenderJSON(markdown string) (json string) {
+	tree := parse.Parse("", []byte(markdown), lute.Options)
+	renderer := render.NewJSONRenderer(tree)
+	output := renderer.Render()
+	json = string(output)
+	return
+}
+
 // Space 用于在 text 中的中西文之间插入空格。
 func (lute *Lute) Space(text string) string {
 	return render.Space0(text)

--- a/render/json_renderer.go
+++ b/render/json_renderer.go
@@ -12,7 +12,9 @@ package render
 
 import (
 	"fmt"
+	"github.com/88250/lute/html"
 	"github.com/88250/lute/lex"
+	"go/format"
 	"strings"
 
 	"github.com/88250/lute/ast"
@@ -20,7 +22,7 @@ import (
 	"github.com/88250/lute/util"
 )
 
-// EChartsJSONRenderer 描述了 JSON 渲染器。
+// JSONRenderer 描述了 JSON 渲染器。
 type JSONRenderer struct {
 	*BaseRenderer
 }
@@ -35,11 +37,11 @@ func NewJSONRenderer(tree *parse.Tree) Renderer {
 	ret.RendererFuncs[ast.NodeCodeSpanOpenMarker] = ret.renderCodeSpanOpenMarker
 	ret.RendererFuncs[ast.NodeCodeSpanContent] = ret.renderCodeSpanContent
 	ret.RendererFuncs[ast.NodeCodeSpanCloseMarker] = ret.renderCodeSpanCloseMarker
-	//ret.RendererFuncs[ast.NodeCodeBlock] = ret.renderCodeBlock
-	//ret.RendererFuncs[ast.NodeCodeBlockFenceOpenMarker] = ret.renderCodeBlockOpenMarker
-	//ret.RendererFuncs[ast.NodeCodeBlockFenceInfoMarker] = ret.renderCodeBlockInfoMarker
-	//ret.RendererFuncs[ast.NodeCodeBlockCode] = ret.renderCodeBlockCode
-	//ret.RendererFuncs[ast.NodeCodeBlockFenceCloseMarker] = ret.renderCodeBlockCloseMarker
+	ret.RendererFuncs[ast.NodeCodeBlock] = ret.renderCodeBlock
+	ret.RendererFuncs[ast.NodeCodeBlockFenceOpenMarker] = ret.renderCodeBlockOpenMarker
+	ret.RendererFuncs[ast.NodeCodeBlockFenceInfoMarker] = ret.renderCodeBlockInfoMarker
+	ret.RendererFuncs[ast.NodeCodeBlockCode] = ret.renderCodeBlockCode
+	ret.RendererFuncs[ast.NodeCodeBlockFenceCloseMarker] = ret.renderCodeBlockCloseMarker
 	ret.RendererFuncs[ast.NodeMathBlock] = ret.renderMathBlock
 	ret.RendererFuncs[ast.NodeMathBlockOpenMarker] = ret.renderMathBlockOpenMarker
 	ret.RendererFuncs[ast.NodeMathBlockContent] = ret.renderMathBlockContent
@@ -140,54 +142,6 @@ func NewJSONRenderer(tree *parse.Tree) Renderer {
 	//ret.RendererFuncs[ast.NodeSuperBlockOpenMarker] = ret.renderSuperBlockOpenMarker
 	//ret.RendererFuncs[ast.NodeSuperBlockLayoutMarker] = ret.renderSuperBlockLayoutMarker
 	//ret.RendererFuncs[ast.NodeSuperBlockCloseMarker] = ret.renderSuperBlockCloseMarker
-
-	//ret.RendererFuncs[ast.NodeParagraph] = ret.renderParagraph  // 已测试
-	//ret.RendererFuncs[ast.NodeText] = ret.renderText  // TODO 需要酌情清除
-	//ret.RendererFuncs[ast.NodeCodeSpanContent] = ret.renderCodeSpanContent  // 解析行内代码块，已测试
-	//ret.RendererFuncs[ast.NodeCodeSpan] = ret.renderCodeSpan  // TODO 移除
-	////ret.RendererFuncs[ast.NodeCodeBlock] = ret.renderCodeBlock  // TODO 处理代码块
-	////ret.RendererFuncs[ast.NodeMathBlock] = ret.renderMathBlock  // TODO 移除
-	//ret.RendererFuncs[ast.NodeMathBlockContent] = ret.renderMathBlockContent  // 解析数学块公式，已测试
-	////ret.RendererFuncs[ast.NodeInlineMath] = ret.renderInlineMath  // TODO 移除
-	//ret.RendererFuncs[ast.NodeInlineMathContent] = ret.renderInlineMathContent  // 解析行内数学公式，已测试
-	//ret.RendererFuncs[ast.NodeEmphasis] = ret.renderEmphasis // 已测试
-	//ret.RendererFuncs[ast.NodeStrong] = ret.renderStrong // 已测试
-	//ret.RendererFuncs[ast.NodeBlockquote] = ret.renderBlockquote // 已测试
-	//ret.RendererFuncs[ast.NodeHeading] = ret.renderHeading  // 已测试 TODO 指定ID
-	//ret.RendererFuncs[ast.NodeList] = ret.renderList  // 已测试
-	//ret.RendererFuncs[ast.NodeListItem] = ret.renderListItem  // 已测试
-	//ret.RendererFuncs[ast.NodeThematicBreak] = ret.renderThematicBreak  // 已测试
-	//ret.RendererFuncs[ast.NodeHardBreak] = ret.renderHardBreak  // TODO 与InlineHTML冲突
-	//ret.RendererFuncs[ast.NodeSoftBreak] = ret.renderSoftBreak  // 已测试
-	//ret.RendererFuncs[ast.NodeHTMLBlock] = ret.renderHTML  // TODO HTML块
-	//ret.RendererFuncs[ast.NodeInlineHTML] = ret.renderInlineHTML  // TODO 已测试
-	//ret.RendererFuncs[ast.NodeLink] = ret.renderLink  // TODO 渲染链接
-	//ret.RendererFuncs[ast.NodeImage] = ret.renderImage  // TODO 渲染图片
-	//ret.RendererFuncs[ast.NodeStrikethrough] = ret.renderStrikethrough  // 已测试
-	//ret.RendererFuncs[ast.NodeTaskListItemMarker] = ret.renderTaskListItemMarker  // 已测试
-	//ret.RendererFuncs[ast.NodeTable] = ret.renderTable  // 已测试
-	//ret.RendererFuncs[ast.NodeTableHead] = ret.renderTableHead // 已测试
-	//ret.RendererFuncs[ast.NodeTableRow] = ret.renderTableRow // 已测试
-	//ret.RendererFuncs[ast.NodeTableCell] = ret.renderTableCell  // 已测试
-	//ret.RendererFuncs[ast.NodeEmoji] = ret.renderEmoji  // 已测试
-	//ret.RendererFuncs[ast.NodeEmojiUnicode] = ret.renderEmojiUnicode  // 已测试
-	//ret.RendererFuncs[ast.NodeEmojiImg] = ret.renderEmojiImg  // 已测试
-	//ret.RendererFuncs[ast.NodeEmojiAlias] = ret.renderEmojiAlias  // 已测试
-	//ret.RendererFuncs[ast.NodeFootnotesDef] = ret.renderFootnotesDef  // TODO
-	//ret.RendererFuncs[ast.NodeFootnotesRef] = ret.renderFootnotesRef  // TODO
-	//ret.RendererFuncs[ast.NodeToC] = ret.renderToC  // TODO 渲染TOC
-	//ret.RendererFuncs[ast.NodeBackslash] = ret.renderBackslash  // TODO 处理中括号，触发条件不明
-	//ret.RendererFuncs[ast.NodeBackslashContent] = ret.renderBackslashContent  // TODO 处理中括号，触发条件不明
-	//ret.RendererFuncs[ast.NodeHTMLEntity] = ret.renderHtmlEntity  // 已测试
-	//ret.RendererFuncs[ast.NodeYamlFrontMatter] = ret.renderYamlFrontMatter  // TODO 处理yaml
-	//ret.RendererFuncs[ast.NodeBlockRef] = ret.renderBlockRef
-	//ret.RendererFuncs[ast.NodeMark] = ret.renderMark  // TODO 处理高亮
-	//ret.RendererFuncs[ast.NodeSup] = ret.renderSup  // TODO 处理上下角标
-	//ret.RendererFuncs[ast.NodeSub] = ret.renderSub  // TODO
-	//ret.RendererFuncs[ast.NodeKramdownBlockIAL] = ret.renderKramdownBlockIAL  // TODO 处理Kramdown
-	//ret.RendererFuncs[ast.NodeKramdownSpanIAL] = ret.renderKramdownSpanIAL  // TODO 处理Kramdown
-	//ret.RendererFuncs[ast.NodeBlockEmbed] = ret.renderBlockEmbed  // TODO 内容块嵌入
-	//ret.RendererFuncs[ast.NodeBlockQueryEmbed] = ret.renderBlockQueryEmbed  // TODO 内容块引用
 	ret.DefaultRendererFunc = ret.renderDefault
 	return ret
 }
@@ -319,6 +273,55 @@ func (r *JSONRenderer) renderCodeSpanContent(node *ast.Node, entering bool) ast.
 func (r *JSONRenderer) renderCodeSpanCloseMarker(node *ast.Node, entering bool) ast.WalkStatus {
 	return ast.WalkContinue
 }
+
+// 渲染代码块
+func (r *JSONRenderer) renderCodeBlock(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+func (r *JSONRenderer) renderCodeBlockOpenMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+func (r *JSONRenderer) renderCodeBlockInfoMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderCodeBlockCode(node *ast.Node, entering bool) ast.WalkStatus {
+	var language string
+	if 0 < len(node.Previous.CodeBlockInfo) {
+		infoWords := lex.Split(node.Previous.CodeBlockInfo, lex.ItemSpace)
+		language = util.BytesToStr(infoWords[0])
+	}
+	if entering {
+		r.openObj()
+		tokens := node.Tokens
+		if 0 < len(node.Previous.CodeBlockInfo) {
+			if isGo(language) {
+				if buf, err := format.Source(tokens); nil == err {
+					tokens = buf
+				}
+			}
+			r.language(ast.NodeCodeBlock, util.BytesToStr(tokens), language)
+
+			if "mindmap" == language {
+				// 给echarts调用
+				json := r.renderMindmap(tokens)
+				r.mindMap(util.BytesToStr(json))
+			}
+		} else {
+			language = detectLanguage(tokens)
+			tokens = html.EscapeHTML(tokens)
+			r.language(ast.NodeCodeBlock, util.BytesToStr(tokens), language)
+		}
+	} else {
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderCodeBlockCloseMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
 
 func (r *JSONRenderer) renderMathBlock(node *ast.Node, entering bool) ast.WalkStatus {
 	return ast.WalkContinue
@@ -768,7 +771,7 @@ func (r *JSONRenderer) renderHtmlEntity(node *ast.Node, entering bool) ast.WalkS
 	return ast.WalkContinue
 }
 
-//// TODO 需要检验KramdownBlockIAL
+// TODO https://kramdown.gettalong.org/syntax.html#inline-attribute-lists
 //func (r *JSONRenderer) renderKramdownBlockIAL(node *ast.Node, entering bool) ast.WalkStatus {
 //	if entering {
 //		if nil == node.Previous {
@@ -912,19 +915,6 @@ func (r *JSONRenderer) renderTaskListItemMarker(node *ast.Node, entering bool) a
 	return ast.WalkContinue
 }
 
-// TODO 重新考虑处理代码内容和语言类型
-//func (r *JSONRenderer) renderCodeBlock(node *ast.Node, entering bool) ast.WalkStatus {
-//	if entering {
-//		//r.leaf(node.Type, "Code Block\npre.code", node)
-//		r.openObj()
-//		fmt.Println(node.Children)
-//		r.val(node.Type, util.BytesToStr(node.FirstChild.Tokens), node)
-//	} else {
-//		r.closeObj(node)
-//	}
-//	return ast.WalkContinue
-//}
-
 func (r *JSONRenderer) leaf(nodeType ast.NodeType, val string, node *ast.Node) {
 	r.openObj()
 	r.val(nodeType, val)
@@ -934,35 +924,30 @@ func (r *JSONRenderer) leaf(nodeType ast.NodeType, val string, node *ast.Node) {
 func (r *JSONRenderer) val(nodeType ast.NodeType , val string) {
 	val = strings.ReplaceAll(val, "\\", "\\\\")
 	val = strings.ReplaceAll(val, "\n", "\\n")
-	val = strings.ReplaceAll(val, "\"", "")
-	val = strings.ReplaceAll(val, "'", "")
+	val = strings.ReplaceAll(val, "\"", "\\\"")
+	val = strings.ReplaceAll(val, "'", "\\'")
 	// 要写入Type和Value
 	r.WriteString("\"type\":\"" + nodeType.String()[4:] + "\"" + ",")
 	r.WriteString("\"value\":\"" + val + "\"")
 }
 
-// 写入如果节点是Text
-//func (r *JSONRenderer) text(val string) {
-//	r.WriteString(",\"text\":\"" + val + "\"")
-//}
+func (r *JSONRenderer) language(nodeType ast.NodeType, val string, language string) {
+	// TODO type 节点类型，language 语言类型，value 值
+	val = strings.ReplaceAll(val, "\\", "\\\\")
+	val = strings.ReplaceAll(val, "\n", "\\n")
+	val = strings.ReplaceAll(val, "\"", "\\\"")
+	val = strings.ReplaceAll(val, "'", "\\'")
+	r.WriteString("\"type\":\"" + nodeType.String()[4:] + "\"" + ",")
+	r.WriteString("\"value\":\"" + val + "\"")
+	r.WriteString(",\"language\":\"" + language + "\"")
+}
+
+// 写入 mindmap
+func (r *JSONRenderer) mindMap(val string) {
+	r.WriteString(",\"mindmap\":\"" + val + "\"")
+}
 
 func (r *JSONRenderer) flag(node *ast.Node) {
-	//if !checkIfFlag(node.Parent.Type) {
-	//	// 父节点不是flag
-	//	r.openObj()
-	//	r.WriteString("\"flags\":\"" + node.Type.String()[4:])
-	//} else {
-	//	//	父节点是flag
-	//	r.WriteString(node.Type.String()[4:])
-	//}
-	//// 判断是不是Marker
-	////	不需要闭合的条件 --> 有一个子节点，并且子节点还是flag类型
-	////fmt.Println(node.FirstChild)
-	//if len(node.Children) == 1 && checkIfFlag(node.FirstChild.Type) {
-	//	r.WriteString("|")
-	//} else {
-	//	r.WriteString("\"")
-	//}
 	r.WriteString("\"flag\":\"" + node.Type.String()[4:]+"\"")
 }
 
@@ -971,7 +956,6 @@ func (r *JSONRenderer) openObj() {
 	r.WriteByte('{')
 }
 
-// TODO BUG 关闭对象
 func (r *JSONRenderer) closeObj(node *ast.Node) {
 	r.WriteByte('}')
 	if !r.ignore(node.Next) {

--- a/render/json_renderer.go
+++ b/render/json_renderer.go
@@ -26,7 +26,7 @@ type JSONRenderer struct {
 	*BaseRenderer
 }
 
-// NewEChartsJSONRenderer 创建一个 JSON 渲染器。
+// NewJSONRenderer 创建一个 JSON 渲染器。
 func NewJSONRenderer(tree *parse.Tree) Renderer {
 	ret := &JSONRenderer{NewBaseRenderer(tree)}
 	ret.RendererFuncs[ast.NodeDocument] = ret.renderDocument

--- a/render/json_renderer.go
+++ b/render/json_renderer.go
@@ -779,7 +779,7 @@ func (r *JSONRenderer) renderFootnotesDefBlock(node *ast.Node, entering bool) as
 	return ast.WalkContinue
 }
 
-// TODO 不支持脚注
+// 不支持脚注
 func (r *JSONRenderer) renderFootnotesRef(node *ast.Node, entering bool) ast.WalkStatus {
 	return ast.WalkContinue
 }
@@ -992,6 +992,7 @@ func (r *JSONRenderer) renderSuperBlockCloseMarker(node *ast.Node, entering bool
 	return ast.WalkSkipChildren
 }
 
+// 不支持链接引用
 func (r *JSONRenderer) renderLinkRefDefBlock(node *ast.Node, entering bool) ast.WalkStatus {
 	return ast.WalkSkipChildren
 }

--- a/render/json_renderer.go
+++ b/render/json_renderer.go
@@ -11,7 +11,6 @@
 package render
 
 import (
-	"fmt"
 	"github.com/88250/lute/html"
 	"github.com/88250/lute/lex"
 	"go/format"
@@ -73,7 +72,7 @@ func NewJSONRenderer(tree *parse.Tree) Renderer {
 	ret.RendererFuncs[ast.NodeHTMLBlock] = ret.renderHTML
 	ret.RendererFuncs[ast.NodeInlineHTML] = ret.renderInlineHTML
 	ret.RendererFuncs[ast.NodeLink] = ret.renderLink
-	//ret.RendererFuncs[ast.NodeImage] = ret.renderImage
+	ret.RendererFuncs[ast.NodeImage] = ret.renderImage
 	ret.RendererFuncs[ast.NodeBang] = ret.renderBang
 	ret.RendererFuncs[ast.NodeOpenBracket] = ret.renderOpenBracket
 	ret.RendererFuncs[ast.NodeCloseBracket] = ret.renderCloseBracket
@@ -90,7 +89,7 @@ func NewJSONRenderer(tree *parse.Tree) Renderer {
 	ret.RendererFuncs[ast.NodeStrikethrough1CloseMarker] = ret.renderStrikethrough1CloseMarker
 	ret.RendererFuncs[ast.NodeStrikethrough2OpenMarker] = ret.renderStrikethrough2OpenMarker
 	ret.RendererFuncs[ast.NodeStrikethrough2CloseMarker] = ret.renderStrikethrough2CloseMarker
-	//ret.RendererFuncs[ast.NodeTaskListItemMarker] = ret.renderTaskListItemMarker
+	ret.RendererFuncs[ast.NodeTaskListItemMarker] = ret.renderTaskListItemMarker
 	ret.RendererFuncs[ast.NodeTable] = ret.renderTable
 	ret.RendererFuncs[ast.NodeTableHead] = ret.renderTableHead
 	ret.RendererFuncs[ast.NodeTableRow] = ret.renderTableRow
@@ -99,62 +98,76 @@ func NewJSONRenderer(tree *parse.Tree) Renderer {
 	ret.RendererFuncs[ast.NodeEmojiUnicode] = ret.renderEmojiUnicode
 	ret.RendererFuncs[ast.NodeEmojiImg] = ret.renderEmojiImg
 	ret.RendererFuncs[ast.NodeEmojiAlias] = ret.renderEmojiAlias
-	//ret.RendererFuncs[ast.NodeFootnotesDefBlock] = ret.renderFootnotesDefBlock
-	//ret.RendererFuncs[ast.NodeFootnotesDef] = ret.renderFootnotesDef
-	//ret.RendererFuncs[ast.NodeFootnotesRef] = ret.renderFootnotesRef
-	//ret.RendererFuncs[ast.NodeToC] = ret.renderToC
-	//ret.RendererFuncs[ast.NodeBackslash] = ret.renderBackslash
-	//ret.RendererFuncs[ast.NodeBackslashContent] = ret.renderBackslashContent
+	ret.RendererFuncs[ast.NodeFootnotesDefBlock] = ret.renderFootnotesDefBlock
+	ret.RendererFuncs[ast.NodeFootnotesDef] = ret.renderFootnotesDef
+	ret.RendererFuncs[ast.NodeFootnotesRef] = ret.renderFootnotesRef
+	ret.RendererFuncs[ast.NodeToC] = ret.renderToC
+	ret.RendererFuncs[ast.NodeBackslash] = ret.renderBackslash
+	ret.RendererFuncs[ast.NodeBackslashContent] = ret.renderBackslashContent
 	ret.RendererFuncs[ast.NodeHTMLEntity] = ret.renderHtmlEntity
-	//ret.RendererFuncs[ast.NodeYamlFrontMatter] = ret.renderYamlFrontMatter
-	//ret.RendererFuncs[ast.NodeYamlFrontMatterOpenMarker] = ret.renderYamlFrontMatterOpenMarker
-	//ret.RendererFuncs[ast.NodeYamlFrontMatterContent] = ret.renderYamlFrontMatterContent
-	//ret.RendererFuncs[ast.NodeYamlFrontMatterCloseMarker] = ret.renderYamlFrontMatterCloseMarker
-	//ret.RendererFuncs[ast.NodeBlockRef] = ret.renderBlockRef
-	//ret.RendererFuncs[ast.NodeBlockRefID] = ret.renderBlockRefID
-	//ret.RendererFuncs[ast.NodeBlockRefSpace] = ret.renderBlockRefSpace
-	//ret.RendererFuncs[ast.NodeBlockRefText] = ret.renderBlockRefText
-	//ret.RendererFuncs[ast.NodeMark] = ret.renderMark
-	//ret.RendererFuncs[ast.NodeMark1OpenMarker] = ret.renderMark1OpenMarker
-	//ret.RendererFuncs[ast.NodeMark1CloseMarker] = ret.renderMark1CloseMarker
-	//ret.RendererFuncs[ast.NodeMark2OpenMarker] = ret.renderMark2OpenMarker
-	//ret.RendererFuncs[ast.NodeMark2CloseMarker] = ret.renderMark2CloseMarker
-	//ret.RendererFuncs[ast.NodeSup] = ret.renderSup
-	//ret.RendererFuncs[ast.NodeSupOpenMarker] = ret.renderSupOpenMarker
-	//ret.RendererFuncs[ast.NodeSupCloseMarker] = ret.renderSupCloseMarker
-	//ret.RendererFuncs[ast.NodeSub] = ret.renderSub
-	//ret.RendererFuncs[ast.NodeSubOpenMarker] = ret.renderSubOpenMarker
-	//ret.RendererFuncs[ast.NodeSubCloseMarker] = ret.renderSubCloseMarker
-	//ret.RendererFuncs[ast.NodeKramdownBlockIAL] = ret.renderKramdownBlockIAL
-	//ret.RendererFuncs[ast.NodeKramdownSpanIAL] = ret.renderKramdownSpanIAL
-	//ret.RendererFuncs[ast.NodeBlockQueryEmbed] = ret.renderBlockQueryEmbed
-	//ret.RendererFuncs[ast.NodeBlockQueryEmbedScript] = ret.renderBlockQueryEmbedScript
-	//ret.RendererFuncs[ast.NodeBlockEmbed] = ret.renderBlockEmbed
-	//ret.RendererFuncs[ast.NodeBlockEmbedID] = ret.renderBlockEmbedID
-	//ret.RendererFuncs[ast.NodeBlockEmbedSpace] = ret.renderBlockEmbedSpace
-	//ret.RendererFuncs[ast.NodeBlockEmbedText] = ret.renderBlockEmbedText
-	//ret.RendererFuncs[ast.NodeTag] = ret.renderTag
-	//ret.RendererFuncs[ast.NodeTagOpenMarker] = ret.renderTagOpenMarker
-	//ret.RendererFuncs[ast.NodeTagCloseMarker] = ret.renderTagCloseMarker
-	//ret.RendererFuncs[ast.NodeLinkRefDefBlock] = ret.renderLinkRefDefBlock
-	//ret.RendererFuncs[ast.NodeLinkRefDef] = ret.renderLinkRefDef
-	//ret.RendererFuncs[ast.NodeSuperBlock] = ret.renderSuperBlock
-	//ret.RendererFuncs[ast.NodeSuperBlockOpenMarker] = ret.renderSuperBlockOpenMarker
-	//ret.RendererFuncs[ast.NodeSuperBlockLayoutMarker] = ret.renderSuperBlockLayoutMarker
-	//ret.RendererFuncs[ast.NodeSuperBlockCloseMarker] = ret.renderSuperBlockCloseMarker
+	ret.RendererFuncs[ast.NodeYamlFrontMatter] = ret.renderYamlFrontMatter
+	ret.RendererFuncs[ast.NodeYamlFrontMatterOpenMarker] = ret.renderYamlFrontMatterOpenMarker
+	ret.RendererFuncs[ast.NodeYamlFrontMatterContent] = ret.renderYamlFrontMatterContent
+	ret.RendererFuncs[ast.NodeYamlFrontMatterCloseMarker] = ret.renderYamlFrontMatterCloseMarker
+	ret.RendererFuncs[ast.NodeBlockRef] = ret.renderBlockRef
+	ret.RendererFuncs[ast.NodeBlockRefID] = ret.renderBlockRefID
+	ret.RendererFuncs[ast.NodeBlockRefSpace] = ret.renderBlockRefSpace
+	ret.RendererFuncs[ast.NodeBlockRefText] = ret.renderBlockRefText
+	ret.RendererFuncs[ast.NodeMark] = ret.renderMark
+	ret.RendererFuncs[ast.NodeMark1OpenMarker] = ret.renderMark1OpenMarker
+	ret.RendererFuncs[ast.NodeMark1CloseMarker] = ret.renderMark1CloseMarker
+	ret.RendererFuncs[ast.NodeMark2OpenMarker] = ret.renderMark2OpenMarker
+	ret.RendererFuncs[ast.NodeMark2CloseMarker] = ret.renderMark2CloseMarker
+	ret.RendererFuncs[ast.NodeSup] = ret.renderSup
+	ret.RendererFuncs[ast.NodeSupOpenMarker] = ret.renderSupOpenMarker
+	ret.RendererFuncs[ast.NodeSupCloseMarker] = ret.renderSupCloseMarker
+	ret.RendererFuncs[ast.NodeSub] = ret.renderSub
+	ret.RendererFuncs[ast.NodeSubOpenMarker] = ret.renderSubOpenMarker
+	ret.RendererFuncs[ast.NodeSubCloseMarker] = ret.renderSubCloseMarker
+	ret.RendererFuncs[ast.NodeKramdownBlockIAL] = ret.renderKramdownBlockIAL
+	ret.RendererFuncs[ast.NodeKramdownSpanIAL] = ret.renderKramdownSpanIAL
+	ret.RendererFuncs[ast.NodeBlockQueryEmbed] = ret.renderBlockQueryEmbed
+	ret.RendererFuncs[ast.NodeBlockQueryEmbedScript] = ret.renderBlockQueryEmbedScript
+	ret.RendererFuncs[ast.NodeBlockEmbed] = ret.renderBlockEmbed
+	ret.RendererFuncs[ast.NodeBlockEmbedID] = ret.renderBlockEmbedID
+	ret.RendererFuncs[ast.NodeBlockEmbedSpace] = ret.renderBlockEmbedSpace
+	ret.RendererFuncs[ast.NodeBlockEmbedText] = ret.renderBlockEmbedText
+	ret.RendererFuncs[ast.NodeTag] = ret.renderTag
+	ret.RendererFuncs[ast.NodeTagOpenMarker] = ret.renderTagOpenMarker
+	ret.RendererFuncs[ast.NodeTagCloseMarker] = ret.renderTagCloseMarker
+	ret.RendererFuncs[ast.NodeLinkRefDefBlock] = ret.renderLinkRefDefBlock
+	ret.RendererFuncs[ast.NodeLinkRefDef] = ret.renderLinkRefDef
+	ret.RendererFuncs[ast.NodeSuperBlock] = ret.renderSuperBlock
+	ret.RendererFuncs[ast.NodeSuperBlockOpenMarker] = ret.renderSuperBlockOpenMarker
+	ret.RendererFuncs[ast.NodeSuperBlockLayoutMarker] = ret.renderSuperBlockLayoutMarker
+	ret.RendererFuncs[ast.NodeSuperBlockCloseMarker] = ret.renderSuperBlockCloseMarker
 	ret.DefaultRendererFunc = ret.renderDefault
 	return ret
 }
 
-// TODO AST树核心设计概念
+// AST树核心设计概念
 // 1. 忽略根节点渲染
 // 2. 对于实际只起控制渲染效果的设为flag
 // 3. 妥善处理Marker对于树构建过程中的影响
-// TODO 4. Flag注释
-// Paragraph 新的段
+// 4. 不支持Kramdown
 
-// TODO OpenMarker处理
-// OpenMarker必定上一个节点是其类型根节点
+// ==> Flag注释
+// Paragraph 新的段
+// Emphasis 斜体
+// Strong 加粗
+// Blockquote 引用块
+// ListItem 列表项
+// Strikethrough 删除线
+// TableHead 表头
+// Table 表格
+// TableRow 表行
+// Mark 高亮
+// Sub 下标
+// Sup 上标
+// Tag 标记
+// BlockRef 块引用
+
+// OpenMarker处理
 func isOpenMarker(node *ast.Node) bool {
 	switch node.Type {
 	case ast.NodeCodeBlockFenceOpenMarker,
@@ -178,7 +191,7 @@ func isOpenMarker(node *ast.Node) bool {
 	return false
 }
 
-// TODO CloseMarker处理
+// CloseMarker处理
 func isCloseMarker(node *ast.Node) bool {
 	switch node.Type {
 	case ast.NodeCodeBlockFenceCloseMarker,
@@ -205,7 +218,20 @@ func isCloseMarker(node *ast.Node) bool {
 // 是否是标识
 func isFlag(node *ast.Node) bool {
 	switch node.Type {
-	case ast.NodeParagraph:
+	case ast.NodeParagraph,
+	ast.NodeEmphasis,
+	ast.NodeStrong,
+	ast.NodeBlockquote,
+	ast.NodeListItem,
+	ast.NodeStrikethrough,
+	ast.NodeTableHead,
+	ast.NodeTable,
+	ast.NodeTableRow,
+	ast.NodeMark,
+	ast.NodeSub,
+	ast.NodeSup,
+	ast.NodeTag,
+	ast.NodeBlockRef:
 		return true
 	}
 	return false
@@ -226,7 +252,6 @@ func (r *JSONRenderer) renderParagraph(node *ast.Node, entering bool) ast.WalkSt
 	if entering {
 		r.openObj()
 		r.flag(node)
-		// TODO 判断下一个节点是不是Text
 		r.openChildren(node)
 	} else {
 		r.closeChildren(node)
@@ -235,7 +260,7 @@ func (r *JSONRenderer) renderParagraph(node *ast.Node, entering bool) ast.WalkSt
 	return ast.WalkContinue
 }
 
-// 处理文本 - "text"属性
+// 处理文本
 func (r *JSONRenderer) renderText(node *ast.Node, entering bool) ast.WalkStatus {
 	if entering {
 		r.openObj()
@@ -486,7 +511,7 @@ func (r *JSONRenderer) renderList(node *ast.Node, entering bool) ast.WalkStatus 
 	return ast.WalkContinue
 }
 
-// TODO 修复可能的BUG
+// flag ListItem标识
 func (r *JSONRenderer) renderListItem(node *ast.Node, entering bool) ast.WalkStatus {
 	if entering {
 		r.openObj()
@@ -508,7 +533,7 @@ func (r *JSONRenderer) renderThematicBreak(node *ast.Node, entering bool) ast.Wa
 }
 
 
-// TODO 硬换行，与InlineHTML冲突
+// 硬换行
 func (r *JSONRenderer) renderHardBreak(node *ast.Node, entering bool) ast.WalkStatus {
 	if entering {
 		r.leaf(node.Type, "br", node)
@@ -548,47 +573,23 @@ func (r *JSONRenderer) renderLink(node *ast.Node, entering bool) ast.WalkStatus 
 		dest := node.ChildByType(ast.NodeLinkDest)
 		destTokens := dest.Tokens
 		destTokens = r.Tree.Context.LinkPath(destTokens)
-		if title := node.ChildByType(ast.NodeLinkTitle); nil != title && nil != title.Tokens {
-			r.val(node.Type, util.BytesToStr(title.Tokens) + "|" + util.BytesToStr(destTokens))
-		} else {
-			r.val(node.Type, util.BytesToStr(destTokens))
-		}
+		r.val(node.Type, util.BytesToStr(destTokens))
 	} else {
 		r.closeObj(node)
 	}
 	return ast.WalkContinue
 }
 
-// TODO 处理图片
+// 处理图片
 func (r *JSONRenderer) renderImage(node *ast.Node, entering bool) ast.WalkStatus {
-	//// TODO 处理图片渲染
-	//if entering {
-	//	r.openObj()
-	//	if 0 == r.DisableTags {
-	//		destTokens := node.ChildByType(ast.NodeLinkDest).Tokens
-	//		// 图片的地址
-	//		destTokens = r.Tree.Context.LinkPath(destTokens)
-	//	}
-	//	r.DisableTags++
-	//	return ast.WalkContinue
-	//} else {
-	//	r.closeObj(node)
-	//}
-	//// 获取alt?
-	////
-	//r.DisableTags--
-	//if 0 == r.DisableTags {
-	//	if title := node.ChildByType(ast.NodeLinkTitle); nil != title && nil != title.Tokens {
-	//		// title的值
-	//		//fmt.Println(util.BytesToStr(title.Tokens))
-	//		//r.Write(html.EscapeHTML(title.Tokens))
-	//	}
-	//	ial := r.NodeAttrsStr(node)
-	//	if "" != ial {
-	//		fmt.Println(ial)
-	//		//r.WriteString(" " + ial)
-	//	}
-	//}
+	if entering {
+		r.openObj()
+		destTokens := node.ChildByType(ast.NodeLinkDest).Tokens
+		destTokens = r.Tree.Context.LinkPath(destTokens)
+		r.val(node.Type, util.BytesToStr(destTokens))
+	} else {
+		r.closeObj(node)
+	}
 	return ast.WalkContinue
 }
 
@@ -640,7 +641,7 @@ func (r *JSONRenderer) renderLinkText(node *ast.Node, entering bool) ast.WalkSta
 		} else {
 			tokens = node.Tokens
 		}
-		r.WriteString(",\"text\":" + util.BytesToStr(tokens) + "\"")
+		r.WriteString(",\"title\":\"" + util.BytesToStr(tokens) + "\"")
 	}
 	return ast.WalkContinue
 }
@@ -671,6 +672,22 @@ func (r *JSONRenderer) renderStrikethrough2OpenMarker(node *ast.Node, entering b
 }
 
 func (r *JSONRenderer) renderStrikethrough2CloseMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderTaskListItemMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		check := "false"
+		if node.TaskListItemChecked {
+			check = "true"
+		}
+		r.val(node.Type, check)
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
 	return ast.WalkContinue
 }
 
@@ -758,6 +775,19 @@ func (r *JSONRenderer) renderEmoji(node *ast.Node, entering bool) ast.WalkStatus
 	return ast.WalkContinue
 }
 
+func (r *JSONRenderer) renderFootnotesDefBlock(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+// TODO 不支持脚注
+func (r *JSONRenderer) renderFootnotesRef(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderFootnotesDef(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
 // HTML实体符号处理
 func (r *JSONRenderer) renderHtmlEntity(node *ast.Node, entering bool) ast.WalkStatus {
 	if entering {
@@ -771,148 +801,248 @@ func (r *JSONRenderer) renderHtmlEntity(node *ast.Node, entering bool) ast.WalkS
 	return ast.WalkContinue
 }
 
-// TODO https://kramdown.gettalong.org/syntax.html#inline-attribute-lists
-//func (r *JSONRenderer) renderKramdownBlockIAL(node *ast.Node, entering bool) ast.WalkStatus {
-//	if entering {
-//		if nil == node.Previous {
-//			return ast.WalkContinue
-//		}
-//		id := r.NodeID(node.Previous)
-//		if util.IsDocIAL(node.Tokens) {
-//			id = r.Tree.ID
-//		}
-//		r.leaf(node.Type, "Block IAL\n{: "+id+"}", node)
-//	}
-//	return ast.WalkContinue
-//}
-//
-//func (r *JSONRenderer) renderKramdownSpanIAL(node *ast.Node, entering bool) ast.WalkStatus {
-//	if entering {
-//		if nil == node.Previous {
-//			return ast.WalkContinue
-//		}
-//		id := r.NodeID(node.Previous)
-//		r.leaf(node.Type,"Span IAL\n{: "+id+"}", node)
-//	}
-//	return ast.WalkContinue
-//}
-
-// TODO Mark是指？
-func (r *JSONRenderer) renderMark(node *ast.Node, entering bool) ast.WalkStatus {
+// Yaml处理
+func (r *JSONRenderer) renderYamlFrontMatter(node *ast.Node, entering bool) ast.WalkStatus {
 	if entering {
-		fmt.Println(node.Text())
-		r.leaf(node.Type, "Mark\nmark", node)
+		r.openObj()
+	} else {
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+func (r JSONRenderer) renderYamlFrontMatterOpenMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+func (r JSONRenderer) renderYamlFrontMatterContent(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.val(ast.NodeYamlFrontMatter, util.BytesToStr(node.Tokens))
 	}
 	return ast.WalkSkipChildren
 }
+func (r JSONRenderer) renderYamlFrontMatterCloseMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
 
-// TODO 处理上下角标
+func (r *JSONRenderer) renderBackslashContent(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.val(ast.NodeBackslash, util.BytesToStr(node.Tokens))
+	} else {
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderBackslash(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderToC(node *ast.Node, entering bool) ast.WalkStatus {
+	// 忽略大纲渲染
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderMark(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.flag(node)
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderMark1OpenMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderMark1CloseMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderMark2OpenMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderMark2CloseMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
 func (r *JSONRenderer) renderSup(node *ast.Node, entering bool) ast.WalkStatus {
 	if entering {
-		r.leaf(node.Type, "Sup\nsup", node)
+		r.openObj()
+		r.flag(node)
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
 	}
-	return ast.WalkSkipChildren
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderSupOpenMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+func (r *JSONRenderer) renderSupCloseMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
 }
 
 func (r *JSONRenderer) renderSub(node *ast.Node, entering bool) ast.WalkStatus {
 	if entering {
-		r.leaf(node.Type, "Sub\nsub", node)
+		r.openObj()
+		r.flag(node)
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
 	}
-	return ast.WalkSkipChildren
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderSubOpenMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderSubCloseMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderKramdownBlockIAL(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderKramdownSpanIAL(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
 }
 
 func (r *JSONRenderer) renderBlockQueryEmbed(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderBlockQueryEmbedScript(node *ast.Node, entering bool) ast.WalkStatus {
 	if entering {
-		r.leaf(node.Type,"BlockQueryEmbed\n!{{script}}", node)
+		r.openObj()
+		r.val(ast.NodeBlockQueryEmbed, util.BytesToStr(node.Tokens))
+	} else {
+		r.closeObj(node)
 	}
-	return ast.WalkSkipChildren
+	return ast.WalkContinue
 }
 
 func (r *JSONRenderer) renderBlockEmbed(node *ast.Node, entering bool) ast.WalkStatus {
 	if entering {
-		r.leaf(node.Type,"BlockEmbed\n!((id))", node)
+		r.openObj()
+	} else {
+		r.closeObj(node)
 	}
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderBlockEmbedID(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderBlockEmbedSpace(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderBlockEmbedText(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.val(ast.NodeBlockEmbed, util.BytesToStr(node.Tokens))
+	}
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderTag(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.flag(node)
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderTagOpenMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderTagCloseMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderSuperBlock(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderSuperBlockOpenMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkSkipChildren
+}
+
+func (r *JSONRenderer) renderSuperBlockLayoutMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkSkipChildren
+}
+
+func (r *JSONRenderer) renderSuperBlockCloseMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkSkipChildren
+}
+
+func (r *JSONRenderer) renderLinkRefDefBlock(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkSkipChildren
+}
+
+func (r *JSONRenderer) renderLinkRefDef(node *ast.Node, entering bool) ast.WalkStatus {
 	return ast.WalkSkipChildren
 }
 
 func (r *JSONRenderer) renderBlockRef(node *ast.Node, entering bool) ast.WalkStatus {
 	if entering {
-		r.leaf(node.Type,"BlockRef\n((id))", node)
+		r.openObj()
+		r.flag(node)
+	} else {
+		r.closeObj(node)
 	}
-	return ast.WalkSkipChildren
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderBlockRefID(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderBlockRefSpace(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderBlockRefText(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+	}
+	return ast.WalkContinue
 }
 
 func (r *JSONRenderer) renderDefault(n *ast.Node, entering bool) ast.WalkStatus {
 	return ast.WalkContinue
 }
 
-func (r *JSONRenderer) renderYamlFrontMatter(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		r.leaf(node.Type, "Front Matter\nYAML", node)
-	}
-	return ast.WalkSkipChildren
-}
-
-func (r *JSONRenderer) renderBackslashContent(node *ast.Node, entering bool) ast.WalkStatus {
-	return ast.WalkSkipChildren
-}
-
-func (r *JSONRenderer) renderBackslash(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		r.leaf(node.Type, "Blackslash\ndiv", node)
-	}
-	return ast.WalkSkipChildren
-}
-
-func (r *JSONRenderer) renderToC(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		r.leaf(node.Type, "ToC\ndiv", node)
-	}
-	return ast.WalkSkipChildren
-}
-
-func (r *JSONRenderer) renderFootnotesRef(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		r.leaf(node.Type, "Footnotes Ref\ndiv", node)
-	}
-	return ast.WalkSkipChildren
-}
-
-func (r *JSONRenderer) renderFootnotesDef(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		r.openObj()
-		r.val(node.Type, node.Text())
-		r.openChildren(node)
-	} else {
-		r.closeChildren(node)
-		r.closeObj(node)
-	}
-	return ast.WalkContinue
-}
-
-// TODO HTML块
 func (r *JSONRenderer) renderHTML(node *ast.Node, entering bool) ast.WalkStatus {
 	if entering {
-		r.leaf(node.Type, "HTML Block\n", node)
-	}
-	return ast.WalkSkipChildren
-}
-
-func (r *JSONRenderer) renderTaskListItemMarker(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
 		r.openObj()
-		check := "false"
-		if node.TaskListItemChecked {
-			check = "true"
+		tokens := node.Tokens
+		if r.Option.Sanitize {
+			tokens = sanitize(tokens)
 		}
-		// 返回勾选情况
-		r.val(node.Type, check)
-		r.openChildren(node)
+		r.val(node.Type, util.BytesToStr(tokens))
 	} else {
-		r.closeChildren(node)
 		r.closeObj(node)
 	}
-	return ast.WalkContinue
+	return ast.WalkSkipChildren
 }
 
 func (r *JSONRenderer) leaf(nodeType ast.NodeType, val string, node *ast.Node) {
@@ -932,7 +1062,6 @@ func (r *JSONRenderer) val(nodeType ast.NodeType , val string) {
 }
 
 func (r *JSONRenderer) language(nodeType ast.NodeType, val string, language string) {
-	// TODO type 节点类型，language 语言类型，value 值
 	val = strings.ReplaceAll(val, "\\", "\\\\")
 	val = strings.ReplaceAll(val, "\n", "\\n")
 	val = strings.ReplaceAll(val, "\"", "\\\"")

--- a/render/json_renderer.go
+++ b/render/json_renderer.go
@@ -1,0 +1,828 @@
+// Lute - 一款对中文语境优化的 Markdown 引擎，支持 Go 和 JavaScript
+// Copyright (c) 2019-present, b3log.org
+//
+// Lute is licensed under Mulan PSL v2.
+// You can use this software according to the terms and conditions of the Mulan PSL v2.
+// You may obtain a copy of Mulan PSL v2 at:
+//         http://license.coscl.org.cn/MulanPSL2
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+// See the Mulan PSL v2 for more details.
+
+package render
+
+import (
+	"fmt"
+	"github.com/88250/lute/lex"
+	"strings"
+
+	"github.com/88250/lute/ast"
+	"github.com/88250/lute/parse"
+	"github.com/88250/lute/util"
+)
+
+// EChartsJSONRenderer 描述了 JSON 渲染器。
+type JSONRenderer struct {
+	*BaseRenderer
+}
+
+// NewEChartsJSONRenderer 创建一个 JSON 渲染器。
+func NewJSONRenderer(tree *parse.Tree) Renderer {
+	ret := &JSONRenderer{NewBaseRenderer(tree)}
+	ret.RendererFuncs[ast.NodeDocument] = ret.renderDocument
+	ret.RendererFuncs[ast.NodeParagraph] = ret.renderParagraph
+	//ret.RendererFuncs[ast.NodeText] = ret.renderText
+	//ret.RendererFuncs[ast.NodeCodeSpan] = ret.renderCodeSpan
+	//ret.RendererFuncs[ast.NodeCodeSpanOpenMarker] = ret.renderCodeSpanOpenMarker
+	//ret.RendererFuncs[ast.NodeCodeSpanContent] = ret.renderCodeSpanContent
+	//ret.RendererFuncs[ast.NodeCodeSpanCloseMarker] = ret.renderCodeSpanCloseMarker
+	//ret.RendererFuncs[ast.NodeCodeBlock] = ret.renderCodeBlock
+	//ret.RendererFuncs[ast.NodeCodeBlockFenceOpenMarker] = ret.renderCodeBlockOpenMarker
+	//ret.RendererFuncs[ast.NodeCodeBlockFenceInfoMarker] = ret.renderCodeBlockInfoMarker
+	//ret.RendererFuncs[ast.NodeCodeBlockCode] = ret.renderCodeBlockCode
+	//ret.RendererFuncs[ast.NodeCodeBlockFenceCloseMarker] = ret.renderCodeBlockCloseMarker
+	//ret.RendererFuncs[ast.NodeMathBlock] = ret.renderMathBlock
+	//ret.RendererFuncs[ast.NodeMathBlockOpenMarker] = ret.renderMathBlockOpenMarker
+	//ret.RendererFuncs[ast.NodeMathBlockContent] = ret.renderMathBlockContent
+	//ret.RendererFuncs[ast.NodeMathBlockCloseMarker] = ret.renderMathBlockCloseMarker
+	//ret.RendererFuncs[ast.NodeInlineMath] = ret.renderInlineMath
+	//ret.RendererFuncs[ast.NodeInlineMathOpenMarker] = ret.renderInlineMathOpenMarker
+	//ret.RendererFuncs[ast.NodeInlineMathContent] = ret.renderInlineMathContent
+	//ret.RendererFuncs[ast.NodeInlineMathCloseMarker] = ret.renderInlineMathCloseMarker
+	//ret.RendererFuncs[ast.NodeEmphasis] = ret.renderEmphasis
+	//ret.RendererFuncs[ast.NodeEmA6kOpenMarker] = ret.renderEmAsteriskOpenMarker
+	//ret.RendererFuncs[ast.NodeEmA6kCloseMarker] = ret.renderEmAsteriskCloseMarker
+	//ret.RendererFuncs[ast.NodeEmU8eOpenMarker] = ret.renderEmUnderscoreOpenMarker
+	//ret.RendererFuncs[ast.NodeEmU8eCloseMarker] = ret.renderEmUnderscoreCloseMarker
+	//ret.RendererFuncs[ast.NodeStrong] = ret.renderStrong
+	//ret.RendererFuncs[ast.NodeStrongA6kOpenMarker] = ret.renderStrongA6kOpenMarker
+	//ret.RendererFuncs[ast.NodeStrongA6kCloseMarker] = ret.renderStrongA6kCloseMarker
+	//ret.RendererFuncs[ast.NodeStrongU8eOpenMarker] = ret.renderStrongU8eOpenMarker
+	//ret.RendererFuncs[ast.NodeStrongU8eCloseMarker] = ret.renderStrongU8eCloseMarker
+	//ret.RendererFuncs[ast.NodeBlockquote] = ret.renderBlockquote
+	//ret.RendererFuncs[ast.NodeBlockquoteMarker] = ret.renderBlockquoteMarker
+	//ret.RendererFuncs[ast.NodeHeading] = ret.renderHeading
+	//ret.RendererFuncs[ast.NodeHeadingC8hMarker] = ret.renderHeadingC8hMarker
+	//ret.RendererFuncs[ast.NodeHeadingID] = ret.renderHeadingID
+	//ret.RendererFuncs[ast.NodeList] = ret.renderList
+	//ret.RendererFuncs[ast.NodeListItem] = ret.renderListItem
+	//ret.RendererFuncs[ast.NodeThematicBreak] = ret.renderThematicBreak
+	//ret.RendererFuncs[ast.NodeHardBreak] = ret.renderHardBreak
+	//ret.RendererFuncs[ast.NodeSoftBreak] = ret.renderSoftBreak
+	//ret.RendererFuncs[ast.NodeHTMLBlock] = ret.renderHTML
+	//ret.RendererFuncs[ast.NodeInlineHTML] = ret.renderInlineHTML
+	//ret.RendererFuncs[ast.NodeLink] = ret.renderLink
+	//ret.RendererFuncs[ast.NodeImage] = ret.renderImage
+	//ret.RendererFuncs[ast.NodeBang] = ret.renderBang
+	//ret.RendererFuncs[ast.NodeOpenBracket] = ret.renderOpenBracket
+	//ret.RendererFuncs[ast.NodeCloseBracket] = ret.renderCloseBracket
+	//ret.RendererFuncs[ast.NodeOpenParen] = ret.renderOpenParen
+	//ret.RendererFuncs[ast.NodeCloseParen] = ret.renderCloseParen
+	//ret.RendererFuncs[ast.NodeOpenBrace] = ret.renderOpenBrace
+	//ret.RendererFuncs[ast.NodeCloseBrace] = ret.renderCloseBrace
+	//ret.RendererFuncs[ast.NodeLinkText] = ret.renderLinkText
+	//ret.RendererFuncs[ast.NodeLinkSpace] = ret.renderLinkSpace
+	//ret.RendererFuncs[ast.NodeLinkDest] = ret.renderLinkDest
+	//ret.RendererFuncs[ast.NodeLinkTitle] = ret.renderLinkTitle
+	//ret.RendererFuncs[ast.NodeStrikethrough] = ret.renderStrikethrough
+	//ret.RendererFuncs[ast.NodeStrikethrough1OpenMarker] = ret.renderStrikethrough1OpenMarker
+	//ret.RendererFuncs[ast.NodeStrikethrough1CloseMarker] = ret.renderStrikethrough1CloseMarker
+	//ret.RendererFuncs[ast.NodeStrikethrough2OpenMarker] = ret.renderStrikethrough2OpenMarker
+	//ret.RendererFuncs[ast.NodeStrikethrough2CloseMarker] = ret.renderStrikethrough2CloseMarker
+	//ret.RendererFuncs[ast.NodeTaskListItemMarker] = ret.renderTaskListItemMarker
+	//ret.RendererFuncs[ast.NodeTable] = ret.renderTable
+	//ret.RendererFuncs[ast.NodeTableHead] = ret.renderTableHead
+	//ret.RendererFuncs[ast.NodeTableRow] = ret.renderTableRow
+	//ret.RendererFuncs[ast.NodeTableCell] = ret.renderTableCell
+	//ret.RendererFuncs[ast.NodeEmoji] = ret.renderEmoji
+	//ret.RendererFuncs[ast.NodeEmojiUnicode] = ret.renderEmojiUnicode
+	//ret.RendererFuncs[ast.NodeEmojiImg] = ret.renderEmojiImg
+	//ret.RendererFuncs[ast.NodeEmojiAlias] = ret.renderEmojiAlias
+	//ret.RendererFuncs[ast.NodeFootnotesDefBlock] = ret.renderFootnotesDefBlock
+	//ret.RendererFuncs[ast.NodeFootnotesDef] = ret.renderFootnotesDef
+	//ret.RendererFuncs[ast.NodeFootnotesRef] = ret.renderFootnotesRef
+	//ret.RendererFuncs[ast.NodeToC] = ret.renderToC
+	//ret.RendererFuncs[ast.NodeBackslash] = ret.renderBackslash
+	//ret.RendererFuncs[ast.NodeBackslashContent] = ret.renderBackslashContent
+	//ret.RendererFuncs[ast.NodeHTMLEntity] = ret.renderHtmlEntity
+	//ret.RendererFuncs[ast.NodeYamlFrontMatter] = ret.renderYamlFrontMatter
+	//ret.RendererFuncs[ast.NodeYamlFrontMatterOpenMarker] = ret.renderYamlFrontMatterOpenMarker
+	//ret.RendererFuncs[ast.NodeYamlFrontMatterContent] = ret.renderYamlFrontMatterContent
+	//ret.RendererFuncs[ast.NodeYamlFrontMatterCloseMarker] = ret.renderYamlFrontMatterCloseMarker
+	//ret.RendererFuncs[ast.NodeBlockRef] = ret.renderBlockRef
+	//ret.RendererFuncs[ast.NodeBlockRefID] = ret.renderBlockRefID
+	//ret.RendererFuncs[ast.NodeBlockRefSpace] = ret.renderBlockRefSpace
+	//ret.RendererFuncs[ast.NodeBlockRefText] = ret.renderBlockRefText
+	//ret.RendererFuncs[ast.NodeMark] = ret.renderMark
+	//ret.RendererFuncs[ast.NodeMark1OpenMarker] = ret.renderMark1OpenMarker
+	//ret.RendererFuncs[ast.NodeMark1CloseMarker] = ret.renderMark1CloseMarker
+	//ret.RendererFuncs[ast.NodeMark2OpenMarker] = ret.renderMark2OpenMarker
+	//ret.RendererFuncs[ast.NodeMark2CloseMarker] = ret.renderMark2CloseMarker
+	//ret.RendererFuncs[ast.NodeSup] = ret.renderSup
+	//ret.RendererFuncs[ast.NodeSupOpenMarker] = ret.renderSupOpenMarker
+	//ret.RendererFuncs[ast.NodeSupCloseMarker] = ret.renderSupCloseMarker
+	//ret.RendererFuncs[ast.NodeSub] = ret.renderSub
+	//ret.RendererFuncs[ast.NodeSubOpenMarker] = ret.renderSubOpenMarker
+	//ret.RendererFuncs[ast.NodeSubCloseMarker] = ret.renderSubCloseMarker
+	//ret.RendererFuncs[ast.NodeKramdownBlockIAL] = ret.renderKramdownBlockIAL
+	//ret.RendererFuncs[ast.NodeKramdownSpanIAL] = ret.renderKramdownSpanIAL
+	//ret.RendererFuncs[ast.NodeBlockQueryEmbed] = ret.renderBlockQueryEmbed
+	//ret.RendererFuncs[ast.NodeBlockQueryEmbedScript] = ret.renderBlockQueryEmbedScript
+	//ret.RendererFuncs[ast.NodeBlockEmbed] = ret.renderBlockEmbed
+	//ret.RendererFuncs[ast.NodeBlockEmbedID] = ret.renderBlockEmbedID
+	//ret.RendererFuncs[ast.NodeBlockEmbedSpace] = ret.renderBlockEmbedSpace
+	//ret.RendererFuncs[ast.NodeBlockEmbedText] = ret.renderBlockEmbedText
+	//ret.RendererFuncs[ast.NodeTag] = ret.renderTag
+	//ret.RendererFuncs[ast.NodeTagOpenMarker] = ret.renderTagOpenMarker
+	//ret.RendererFuncs[ast.NodeTagCloseMarker] = ret.renderTagCloseMarker
+	//ret.RendererFuncs[ast.NodeLinkRefDefBlock] = ret.renderLinkRefDefBlock
+	//ret.RendererFuncs[ast.NodeLinkRefDef] = ret.renderLinkRefDef
+	//ret.RendererFuncs[ast.NodeSuperBlock] = ret.renderSuperBlock
+	//ret.RendererFuncs[ast.NodeSuperBlockOpenMarker] = ret.renderSuperBlockOpenMarker
+	//ret.RendererFuncs[ast.NodeSuperBlockLayoutMarker] = ret.renderSuperBlockLayoutMarker
+	//ret.RendererFuncs[ast.NodeSuperBlockCloseMarker] = ret.renderSuperBlockCloseMarker
+
+	//ret.RendererFuncs[ast.NodeParagraph] = ret.renderParagraph  // 已测试
+	//ret.RendererFuncs[ast.NodeText] = ret.renderText  // TODO 需要酌情清除
+	//ret.RendererFuncs[ast.NodeCodeSpanContent] = ret.renderCodeSpanContent  // 解析行内代码块，已测试
+	//ret.RendererFuncs[ast.NodeCodeSpan] = ret.renderCodeSpan  // TODO 移除
+	////ret.RendererFuncs[ast.NodeCodeBlock] = ret.renderCodeBlock  // TODO 处理代码块
+	////ret.RendererFuncs[ast.NodeMathBlock] = ret.renderMathBlock  // TODO 移除
+	//ret.RendererFuncs[ast.NodeMathBlockContent] = ret.renderMathBlockContent  // 解析数学块公式，已测试
+	////ret.RendererFuncs[ast.NodeInlineMath] = ret.renderInlineMath  // TODO 移除
+	//ret.RendererFuncs[ast.NodeInlineMathContent] = ret.renderInlineMathContent  // 解析行内数学公式，已测试
+	//ret.RendererFuncs[ast.NodeEmphasis] = ret.renderEmphasis // 已测试
+	//ret.RendererFuncs[ast.NodeStrong] = ret.renderStrong // 已测试
+	//ret.RendererFuncs[ast.NodeBlockquote] = ret.renderBlockquote // 已测试
+	//ret.RendererFuncs[ast.NodeHeading] = ret.renderHeading  // 已测试 TODO 指定ID
+	//ret.RendererFuncs[ast.NodeList] = ret.renderList  // 已测试
+	//ret.RendererFuncs[ast.NodeListItem] = ret.renderListItem  // 已测试
+	//ret.RendererFuncs[ast.NodeThematicBreak] = ret.renderThematicBreak  // 已测试
+	//ret.RendererFuncs[ast.NodeHardBreak] = ret.renderHardBreak  // TODO 与InlineHTML冲突
+	//ret.RendererFuncs[ast.NodeSoftBreak] = ret.renderSoftBreak  // 已测试
+	//ret.RendererFuncs[ast.NodeHTMLBlock] = ret.renderHTML  // TODO HTML块
+	//ret.RendererFuncs[ast.NodeInlineHTML] = ret.renderInlineHTML  // TODO 已测试
+	//ret.RendererFuncs[ast.NodeLink] = ret.renderLink  // TODO 渲染链接
+	//ret.RendererFuncs[ast.NodeImage] = ret.renderImage  // TODO 渲染图片
+	//ret.RendererFuncs[ast.NodeStrikethrough] = ret.renderStrikethrough  // 已测试
+	//ret.RendererFuncs[ast.NodeTaskListItemMarker] = ret.renderTaskListItemMarker  // 已测试
+	//ret.RendererFuncs[ast.NodeTable] = ret.renderTable  // 已测试
+	//ret.RendererFuncs[ast.NodeTableHead] = ret.renderTableHead // 已测试
+	//ret.RendererFuncs[ast.NodeTableRow] = ret.renderTableRow // 已测试
+	//ret.RendererFuncs[ast.NodeTableCell] = ret.renderTableCell  // 已测试
+	//ret.RendererFuncs[ast.NodeEmoji] = ret.renderEmoji  // 已测试
+	//ret.RendererFuncs[ast.NodeEmojiUnicode] = ret.renderEmojiUnicode  // 已测试
+	//ret.RendererFuncs[ast.NodeEmojiImg] = ret.renderEmojiImg  // 已测试
+	//ret.RendererFuncs[ast.NodeEmojiAlias] = ret.renderEmojiAlias  // 已测试
+	//ret.RendererFuncs[ast.NodeFootnotesDef] = ret.renderFootnotesDef  // TODO
+	//ret.RendererFuncs[ast.NodeFootnotesRef] = ret.renderFootnotesRef  // TODO
+	//ret.RendererFuncs[ast.NodeToC] = ret.renderToC  // TODO 渲染TOC
+	//ret.RendererFuncs[ast.NodeBackslash] = ret.renderBackslash  // TODO 处理中括号，触发条件不明
+	//ret.RendererFuncs[ast.NodeBackslashContent] = ret.renderBackslashContent  // TODO 处理中括号，触发条件不明
+	//ret.RendererFuncs[ast.NodeHTMLEntity] = ret.renderHtmlEntity  // 已测试
+	//ret.RendererFuncs[ast.NodeYamlFrontMatter] = ret.renderYamlFrontMatter  // TODO 处理yaml
+	//ret.RendererFuncs[ast.NodeBlockRef] = ret.renderBlockRef
+	//ret.RendererFuncs[ast.NodeMark] = ret.renderMark  // TODO 处理高亮
+	//ret.RendererFuncs[ast.NodeSup] = ret.renderSup  // TODO 处理上下角标
+	//ret.RendererFuncs[ast.NodeSub] = ret.renderSub  // TODO
+	//ret.RendererFuncs[ast.NodeKramdownBlockIAL] = ret.renderKramdownBlockIAL  // TODO 处理Kramdown
+	//ret.RendererFuncs[ast.NodeKramdownSpanIAL] = ret.renderKramdownSpanIAL  // TODO 处理Kramdown
+	//ret.RendererFuncs[ast.NodeBlockEmbed] = ret.renderBlockEmbed  // TODO 内容块嵌入
+	//ret.RendererFuncs[ast.NodeBlockQueryEmbed] = ret.renderBlockQueryEmbed  // TODO 内容块引用
+	//ret.DefaultRendererFunc = ret.renderDefault
+	return ret
+}
+
+// TODO AST树核心设计概念
+// 1. 忽略根节点渲染
+// 2. 对于实际只起控制渲染效果的设为flag
+// 3. 妥善处理Marker对于树构建过程中的影响
+// TODO 4. Flag注释
+// Paragraph 新的段
+
+// 处理根节点
+func (r *JSONRenderer) renderDocument(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.WriteByte(lex.ItemOpenBracket)
+	} else {
+		r.WriteByte(lex.ItemCloseBracket)
+	}
+	return ast.WalkContinue
+}
+
+// TODO 需要检验KramdownBlockIAL
+func (r *JSONRenderer) renderKramdownBlockIAL(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		if nil == node.Previous {
+			return ast.WalkContinue
+		}
+		id := r.NodeID(node.Previous)
+		if util.IsDocIAL(node.Tokens) {
+			id = r.Tree.ID
+		}
+		r.leaf(node.Type, "Block IAL\n{: "+id+"}", node)
+	}
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderKramdownSpanIAL(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		if nil == node.Previous {
+			return ast.WalkContinue
+		}
+		id := r.NodeID(node.Previous)
+		r.leaf(node.Type,"Span IAL\n{: "+id+"}", node)
+	}
+	return ast.WalkContinue
+}
+
+// TODO Mark是指？
+func (r *JSONRenderer) renderMark(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		fmt.Println(node.Text())
+		r.leaf(node.Type, "Mark\nmark", node)
+	}
+	return ast.WalkSkipChildren
+}
+
+// TODO 处理上下角标
+func (r *JSONRenderer) renderSup(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.leaf(node.Type, "Sup\nsup", node)
+	}
+	return ast.WalkSkipChildren
+}
+
+func (r *JSONRenderer) renderSub(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.leaf(node.Type, "Sub\nsub", node)
+	}
+	return ast.WalkSkipChildren
+}
+
+func (r *JSONRenderer) renderBlockQueryEmbed(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.leaf(node.Type,"BlockQueryEmbed\n!{{script}}", node)
+	}
+	return ast.WalkSkipChildren
+}
+
+func (r *JSONRenderer) renderBlockEmbed(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.leaf(node.Type,"BlockEmbed\n!((id))", node)
+	}
+	return ast.WalkSkipChildren
+}
+
+func (r *JSONRenderer) renderBlockRef(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.leaf(node.Type,"BlockRef\n((id))", node)
+	}
+	return ast.WalkSkipChildren
+}
+
+func (r *JSONRenderer) renderDefault(n *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderYamlFrontMatter(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.leaf(node.Type, "Front Matter\nYAML", node)
+	}
+	return ast.WalkSkipChildren
+}
+
+// HTML实体符号处理
+func (r *JSONRenderer) renderHtmlEntity(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.val(node.Type, util.BytesToStr(node.Tokens))
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderBackslashContent(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkSkipChildren
+}
+
+func (r *JSONRenderer) renderBackslash(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.leaf(node.Type, "Blackslash\ndiv", node)
+	}
+	return ast.WalkSkipChildren
+}
+
+func (r *JSONRenderer) renderToC(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.leaf(node.Type, "ToC\ndiv", node)
+	}
+	return ast.WalkSkipChildren
+}
+
+func (r *JSONRenderer) renderFootnotesRef(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.leaf(node.Type, "Footnotes Ref\ndiv", node)
+	}
+	return ast.WalkSkipChildren
+}
+
+func (r *JSONRenderer) renderFootnotesDef(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.val(node.Type, node.Text())
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+// 解析行内数学公式
+func (r *JSONRenderer) renderInlineMathContent(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.val(ast.NodeInlineMath, util.BytesToStr(node.Tokens))
+	} else {
+		r.closeObj(node)
+	}
+	return ast.WalkSkipChildren
+}
+
+// 解析数学块
+func (r *JSONRenderer) renderMathBlockContent(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.val(ast.NodeMathBlock,util.BytesToStr(node.Tokens))
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderEmojiImg(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.leaf(node.Type, util.BytesToStr(node.Tokens), node)
+	}
+	return ast.WalkSkipChildren
+}
+
+func (r *JSONRenderer) renderEmojiUnicode(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.leaf(node.Type, util.BytesToStr(node.Tokens), node)
+	}
+	return ast.WalkSkipChildren
+}
+
+func (r *JSONRenderer) renderEmojiAlias(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkSkipChildren
+}
+
+func (r *JSONRenderer) renderEmoji(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+// TODO 处理表格渲染
+// TODO Cell渲染函数才能拿到对齐
+func (r *JSONRenderer) renderTableCell(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		var align string
+		switch node.TableCellAlign {
+		case 1:
+			align = "left"
+		case 2:
+			align = "center"
+		case 3:
+			align = "right"
+		default:
+			align = "left"
+		}
+		r.openObj()
+		r.val(node.Type, align)
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+// 表格新行标识
+func (r *JSONRenderer) renderTableRow(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.val(node.Type, "")
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+// 表头标识
+func (r *JSONRenderer) renderTableHead(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.val(node.Type, "")
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+// 表格标识
+func (r *JSONRenderer) renderTable(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.val(node.Type, "")
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+// 删除线标识
+func (r *JSONRenderer) renderStrikethrough(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.val(node.Type, "")
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderImage(node *ast.Node, entering bool) ast.WalkStatus {
+	// TODO 处理图片渲染
+	//if entering {
+	//	if 0 == r.DisableTags {
+	//		r.WriteString("<img src=\"")
+	//		destTokens := node.ChildByType(ast.NodeLinkDest).Tokens
+	//		destTokens = r.Tree.Context.LinkPath(destTokens)
+	//		if "" != r.Option.ImageLazyLoading {
+	//			r.Write(html.EscapeHTML(util.StrToBytes(r.Option.ImageLazyLoading)))
+	//			r.WriteString("\" data-src=\"")
+	//		}
+	//		r.Write(html.EscapeHTML(destTokens))
+	//		r.WriteString("\" alt=\"")
+	//	}
+	//	r.DisableTags++
+	//	return ast.WalkContinue
+	//}
+	//
+	//r.DisableTags--
+	//if 0 == r.DisableTags {
+	//	r.WriteByte(lex.ItemDoublequote)
+	//	if title := node.ChildByType(ast.NodeLinkTitle); nil != title && nil != title.Tokens {
+	//		r.WriteString(" title=\"")
+	//		r.Write(html.EscapeHTML(title.Tokens))
+	//		r.WriteByte(lex.ItemDoublequote)
+	//	}
+	//	ial := r.NodeAttrsStr(node)
+	//	if "" != ial {
+	//		r.WriteString(" " + ial)
+	//	}
+	//	r.WriteString(" />")
+	//
+	//	if r.Option.Sanitize {
+	//		buf := r.Writer.Bytes()
+	//		idx := bytes.LastIndex(buf, []byte("<img src="))
+	//		imgBuf := buf[idx:]
+	//		if r.Option.Sanitize {
+	//			imgBuf = sanitize(imgBuf)
+	//		}
+	//		r.Writer.Truncate(idx)
+	//		r.Writer.Write(imgBuf)
+	//	}
+	//}
+	//return ast.WalkContinue
+	if entering {
+		r.openObj()
+		r.val(node.Type, node.Text())
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderLink(node *ast.Node, entering bool) ast.WalkStatus {
+    // TODO 处理链接渲染
+	//if entering {
+	//	r.LinkTextAutoSpacePrevious(node)
+	//
+	//	dest := node.ChildByType(ast.NodeLinkDest)
+	//	destTokens := dest.Tokens
+	//	destTokens = r.Tree.Context.LinkPath(destTokens)
+	//	attrs := [][]string{{"href", util.BytesToStr(html.EscapeHTML(destTokens))}}
+	//	if title := node.ChildByType(ast.NodeLinkTitle); nil != title && nil != title.Tokens {
+	//		attrs = append(attrs, []string{"title", util.BytesToStr(html.EscapeHTML(title.Tokens))})
+	//	}
+	//	r.Tag("a", attrs, false)
+	//} else {
+	//	r.Tag("/a", nil, false)
+	//
+	//	r.LinkTextAutoSpaceNext(node)
+	//}
+	//return ast.WalkContinue
+	if entering {
+		r.openObj()
+		r.val(node.Type, node.Text())
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderHTML(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.leaf(node.Type, "HTML Block\n", node)
+	}
+	return ast.WalkSkipChildren
+}
+
+func (r *JSONRenderer) renderInlineHTML(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		tokens := node.Tokens
+		if r.Option.Sanitize {
+			tokens = sanitize(tokens)
+		}
+		r.val(node.Type, util.BytesToStr(tokens))
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderParagraph(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.flag(node)
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderText(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		text := util.BytesToStr(node.Tokens)
+		r.text(text)
+	}
+	return ast.WalkSkipChildren
+}
+
+func (r *JSONRenderer) renderCodeSpan(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.flag(node)
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+// 渲染行内代码
+func (r *JSONRenderer) renderCodeSpanContent(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.val(node.Type, util.BytesToStr(node.Tokens))
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+// 斜体标志存在
+func (r *JSONRenderer) renderEmphasis(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.val(node.Type, "")
+		//r.flag(node)
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+// 加粗标志存在
+func (r *JSONRenderer) renderStrong(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.flag(node)
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+// 引用标识存在
+func (r *JSONRenderer) renderBlockquote(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.val(node.Type, "")
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+// 标题存在，返回标题等级
+func (r *JSONRenderer) renderHeading(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		h := "h" + headingLevel[node.HeadingLevel:node.HeadingLevel+1]
+		// 标题值为标题等级
+		r.val(node.Type, h)
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderList(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		list := "ul"
+		if 1 == node.ListData.Typ || (3 == node.ListData.Typ && 0 == node.ListData.BulletChar) {
+			list = "ol"
+		}
+		// 值为列表的类型
+		r.val(node.Type, list)
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+// TODO 修复可能的BUG
+func (r *JSONRenderer) renderListItem(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.val(node.Type, node.Text())
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderTaskListItemMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		check := "false"
+		if node.TaskListItemChecked {
+			check = "true"
+		}
+		// 返回勾选情况
+		r.val(node.Type, check)
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+// 分割线
+func (r *JSONRenderer) renderThematicBreak(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.leaf(node.Type, "hr", node)
+	}
+	return ast.WalkSkipChildren
+}
+
+// TODO 硬换行，与InlineHTML冲突
+func (r *JSONRenderer) renderHardBreak(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.leaf(node.Type, "br", node)
+	}
+	return ast.WalkSkipChildren
+}
+
+// \n换行
+func (r *JSONRenderer) renderSoftBreak(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.leaf(node.Type, "\n", node)
+	}
+	return ast.WalkSkipChildren
+}
+
+// TODO 重新考虑处理代码内容和语言类型
+//func (r *JSONRenderer) renderCodeBlock(node *ast.Node, entering bool) ast.WalkStatus {
+//	if entering {
+//		//r.leaf(node.Type, "Code Block\npre.code", node)
+//		r.openObj()
+//		fmt.Println(node.Children)
+//		r.val(node.Type, util.BytesToStr(node.FirstChild.Tokens), node)
+//	} else {
+//		r.closeObj(node)
+//	}
+//	return ast.WalkContinue
+//}
+
+func (r *JSONRenderer) leaf(nodeType ast.NodeType, val string, node *ast.Node) {
+	r.openObj()
+	r.val(nodeType, val)
+	r.closeObj(node)
+}
+
+func (r *JSONRenderer) val(nodeType ast.NodeType , val string) {
+	val = strings.ReplaceAll(val, "\\", "\\\\")
+	val = strings.ReplaceAll(val, "\n", "\\n")
+	val = strings.ReplaceAll(val, "\"", "")
+	val = strings.ReplaceAll(val, "'", "")
+	// 要写入Type和Value
+	r.WriteString("\"type\":\"" + nodeType.String()[4:] + "\"" + ",")
+	r.WriteString("\"value\":\"" + val + "\"")
+}
+
+// 写入如果节点是Text
+func (r *JSONRenderer) text(val string) {
+	r.WriteString(",\"text\":\"" + val + "\"")
+}
+
+func (r *JSONRenderer) flag(node *ast.Node) {
+	//if !checkIfFlag(node.Parent.Type) {
+	//	// 父节点不是flag
+	//	r.openObj()
+	//	r.WriteString("\"flags\":\"" + node.Type.String()[4:])
+	//} else {
+	//	//	父节点是flag
+	//	r.WriteString(node.Type.String()[4:])
+	//}
+	//// 判断是不是Marker
+	////	不需要闭合的条件 --> 有一个子节点，并且子节点还是flag类型
+	////fmt.Println(node.FirstChild)
+	//if len(node.Children) == 1 && checkIfFlag(node.FirstChild.Type) {
+	//	r.WriteString("|")
+	//} else {
+	//	r.WriteString("\"")
+	//}
+	r.WriteString("\"flag\":\"" + node.Type.String()[4:]+"\"")
+}
+
+// 打开对象
+func (r *JSONRenderer) openObj() {
+	r.WriteByte('{')
+}
+
+// 关闭对象
+func (r *JSONRenderer) closeObj(node *ast.Node) {
+	r.WriteByte('}')
+	r.comma()
+}
+
+// 打开子节点
+func (r *JSONRenderer) openChildren(node *ast.Node) {
+	if nil != node.FirstChild {
+		r.WriteString(",\"children\":[")
+	}
+}
+
+// 关闭子节点
+func (r *JSONRenderer) closeChildren(node *ast.Node) {
+	if nil != node.FirstChild {
+		r.WriteByte(']')
+	}
+}
+
+// 逗号
+func (r *JSONRenderer) comma() {
+	r.WriteString(",")
+}

--- a/render/json_renderer.go
+++ b/render/json_renderer.go
@@ -30,46 +30,46 @@ func NewJSONRenderer(tree *parse.Tree) Renderer {
 	ret := &JSONRenderer{NewBaseRenderer(tree)}
 	ret.RendererFuncs[ast.NodeDocument] = ret.renderDocument
 	ret.RendererFuncs[ast.NodeParagraph] = ret.renderParagraph
-	//ret.RendererFuncs[ast.NodeText] = ret.renderText
-	//ret.RendererFuncs[ast.NodeCodeSpan] = ret.renderCodeSpan
-	//ret.RendererFuncs[ast.NodeCodeSpanOpenMarker] = ret.renderCodeSpanOpenMarker
-	//ret.RendererFuncs[ast.NodeCodeSpanContent] = ret.renderCodeSpanContent
-	//ret.RendererFuncs[ast.NodeCodeSpanCloseMarker] = ret.renderCodeSpanCloseMarker
+	ret.RendererFuncs[ast.NodeText] = ret.renderText
+	ret.RendererFuncs[ast.NodeCodeSpan] = ret.renderCodeSpan
+	ret.RendererFuncs[ast.NodeCodeSpanOpenMarker] = ret.renderCodeSpanOpenMarker
+	ret.RendererFuncs[ast.NodeCodeSpanContent] = ret.renderCodeSpanContent
+	ret.RendererFuncs[ast.NodeCodeSpanCloseMarker] = ret.renderCodeSpanCloseMarker
 	//ret.RendererFuncs[ast.NodeCodeBlock] = ret.renderCodeBlock
 	//ret.RendererFuncs[ast.NodeCodeBlockFenceOpenMarker] = ret.renderCodeBlockOpenMarker
 	//ret.RendererFuncs[ast.NodeCodeBlockFenceInfoMarker] = ret.renderCodeBlockInfoMarker
 	//ret.RendererFuncs[ast.NodeCodeBlockCode] = ret.renderCodeBlockCode
 	//ret.RendererFuncs[ast.NodeCodeBlockFenceCloseMarker] = ret.renderCodeBlockCloseMarker
-	//ret.RendererFuncs[ast.NodeMathBlock] = ret.renderMathBlock
-	//ret.RendererFuncs[ast.NodeMathBlockOpenMarker] = ret.renderMathBlockOpenMarker
-	//ret.RendererFuncs[ast.NodeMathBlockContent] = ret.renderMathBlockContent
-	//ret.RendererFuncs[ast.NodeMathBlockCloseMarker] = ret.renderMathBlockCloseMarker
-	//ret.RendererFuncs[ast.NodeInlineMath] = ret.renderInlineMath
-	//ret.RendererFuncs[ast.NodeInlineMathOpenMarker] = ret.renderInlineMathOpenMarker
-	//ret.RendererFuncs[ast.NodeInlineMathContent] = ret.renderInlineMathContent
-	//ret.RendererFuncs[ast.NodeInlineMathCloseMarker] = ret.renderInlineMathCloseMarker
-	//ret.RendererFuncs[ast.NodeEmphasis] = ret.renderEmphasis
-	//ret.RendererFuncs[ast.NodeEmA6kOpenMarker] = ret.renderEmAsteriskOpenMarker
-	//ret.RendererFuncs[ast.NodeEmA6kCloseMarker] = ret.renderEmAsteriskCloseMarker
-	//ret.RendererFuncs[ast.NodeEmU8eOpenMarker] = ret.renderEmUnderscoreOpenMarker
-	//ret.RendererFuncs[ast.NodeEmU8eCloseMarker] = ret.renderEmUnderscoreCloseMarker
-	//ret.RendererFuncs[ast.NodeStrong] = ret.renderStrong
-	//ret.RendererFuncs[ast.NodeStrongA6kOpenMarker] = ret.renderStrongA6kOpenMarker
-	//ret.RendererFuncs[ast.NodeStrongA6kCloseMarker] = ret.renderStrongA6kCloseMarker
-	//ret.RendererFuncs[ast.NodeStrongU8eOpenMarker] = ret.renderStrongU8eOpenMarker
-	//ret.RendererFuncs[ast.NodeStrongU8eCloseMarker] = ret.renderStrongU8eCloseMarker
-	//ret.RendererFuncs[ast.NodeBlockquote] = ret.renderBlockquote
-	//ret.RendererFuncs[ast.NodeBlockquoteMarker] = ret.renderBlockquoteMarker
-	//ret.RendererFuncs[ast.NodeHeading] = ret.renderHeading
-	//ret.RendererFuncs[ast.NodeHeadingC8hMarker] = ret.renderHeadingC8hMarker
-	//ret.RendererFuncs[ast.NodeHeadingID] = ret.renderHeadingID
-	//ret.RendererFuncs[ast.NodeList] = ret.renderList
-	//ret.RendererFuncs[ast.NodeListItem] = ret.renderListItem
-	//ret.RendererFuncs[ast.NodeThematicBreak] = ret.renderThematicBreak
-	//ret.RendererFuncs[ast.NodeHardBreak] = ret.renderHardBreak
-	//ret.RendererFuncs[ast.NodeSoftBreak] = ret.renderSoftBreak
-	//ret.RendererFuncs[ast.NodeHTMLBlock] = ret.renderHTML
-	//ret.RendererFuncs[ast.NodeInlineHTML] = ret.renderInlineHTML
+	ret.RendererFuncs[ast.NodeMathBlock] = ret.renderMathBlock
+	ret.RendererFuncs[ast.NodeMathBlockOpenMarker] = ret.renderMathBlockOpenMarker
+	ret.RendererFuncs[ast.NodeMathBlockContent] = ret.renderMathBlockContent
+	ret.RendererFuncs[ast.NodeMathBlockCloseMarker] = ret.renderMathBlockCloseMarker
+	ret.RendererFuncs[ast.NodeInlineMath] = ret.renderInlineMath
+	ret.RendererFuncs[ast.NodeInlineMathOpenMarker] = ret.renderInlineMathOpenMarker
+	ret.RendererFuncs[ast.NodeInlineMathContent] = ret.renderInlineMathContent
+	ret.RendererFuncs[ast.NodeInlineMathCloseMarker] = ret.renderInlineMathCloseMarker
+	ret.RendererFuncs[ast.NodeEmphasis] = ret.renderEmphasis
+	ret.RendererFuncs[ast.NodeEmA6kOpenMarker] = ret.renderEmAsteriskOpenMarker
+	ret.RendererFuncs[ast.NodeEmA6kCloseMarker] = ret.renderEmAsteriskCloseMarker
+	ret.RendererFuncs[ast.NodeEmU8eOpenMarker] = ret.renderEmUnderscoreOpenMarker
+	ret.RendererFuncs[ast.NodeEmU8eCloseMarker] = ret.renderEmUnderscoreCloseMarker
+	ret.RendererFuncs[ast.NodeStrong] = ret.renderStrong
+	ret.RendererFuncs[ast.NodeStrongA6kOpenMarker] = ret.renderStrongA6kOpenMarker
+	ret.RendererFuncs[ast.NodeStrongA6kCloseMarker] = ret.renderStrongA6kCloseMarker
+	ret.RendererFuncs[ast.NodeStrongU8eOpenMarker] = ret.renderStrongU8eOpenMarker
+	ret.RendererFuncs[ast.NodeStrongU8eCloseMarker] = ret.renderStrongU8eCloseMarker
+	ret.RendererFuncs[ast.NodeBlockquote] = ret.renderBlockquote
+	ret.RendererFuncs[ast.NodeBlockquoteMarker] = ret.renderBlockquoteMarker
+	ret.RendererFuncs[ast.NodeHeading] = ret.renderHeading
+	ret.RendererFuncs[ast.NodeHeadingC8hMarker] = ret.renderHeadingC8hMarker
+	ret.RendererFuncs[ast.NodeHeadingID] = ret.renderHeadingID
+	ret.RendererFuncs[ast.NodeList] = ret.renderList
+	ret.RendererFuncs[ast.NodeListItem] = ret.renderListItem
+	ret.RendererFuncs[ast.NodeThematicBreak] = ret.renderThematicBreak
+	ret.RendererFuncs[ast.NodeHardBreak] = ret.renderHardBreak
+	ret.RendererFuncs[ast.NodeSoftBreak] = ret.renderSoftBreak
+	ret.RendererFuncs[ast.NodeHTMLBlock] = ret.renderHTML
+	ret.RendererFuncs[ast.NodeInlineHTML] = ret.renderInlineHTML
 	//ret.RendererFuncs[ast.NodeLink] = ret.renderLink
 	//ret.RendererFuncs[ast.NodeImage] = ret.renderImage
 	//ret.RendererFuncs[ast.NodeBang] = ret.renderBang
@@ -188,7 +188,7 @@ func NewJSONRenderer(tree *parse.Tree) Renderer {
 	//ret.RendererFuncs[ast.NodeKramdownSpanIAL] = ret.renderKramdownSpanIAL  // TODO 处理Kramdown
 	//ret.RendererFuncs[ast.NodeBlockEmbed] = ret.renderBlockEmbed  // TODO 内容块嵌入
 	//ret.RendererFuncs[ast.NodeBlockQueryEmbed] = ret.renderBlockQueryEmbed  // TODO 内容块引用
-	//ret.DefaultRendererFunc = ret.renderDefault
+	ret.DefaultRendererFunc = ret.renderDefault
 	return ret
 }
 
@@ -198,6 +198,64 @@ func NewJSONRenderer(tree *parse.Tree) Renderer {
 // 3. 妥善处理Marker对于树构建过程中的影响
 // TODO 4. Flag注释
 // Paragraph 新的段
+
+// TODO OpenMarker处理
+// OpenMarker必定上一个节点是其类型根节点
+func isOpenMarker(node *ast.Node) bool {
+	switch node.Type {
+	case ast.NodeCodeBlockFenceOpenMarker,
+		ast.NodeEmA6kOpenMarker,
+		ast.NodeEmU8eOpenMarker,
+		ast.NodeStrongA6kOpenMarker,
+		ast.NodeStrongU8eOpenMarker,
+		ast.NodeCodeSpanOpenMarker,
+		ast.NodeStrikethrough1OpenMarker,
+		ast.NodeStrikethrough2OpenMarker,
+		ast.NodeMathBlockOpenMarker,
+		ast.NodeInlineMathOpenMarker,
+		ast.NodeYamlFrontMatterOpenMarker,
+		ast.NodeMark1OpenMarker,
+		ast.NodeMark2OpenMarker,
+		ast.NodeTagOpenMarker,
+		ast.NodeSupOpenMarker,
+		ast.NodeSubOpenMarker:
+		return true
+	}
+	return false
+}
+
+// TODO CloseMarker处理
+func isCloseMarker(node *ast.Node) bool {
+	switch node.Type {
+	case ast.NodeCodeBlockFenceCloseMarker,
+		ast.NodeEmA6kCloseMarker,
+		ast.NodeEmU8eCloseMarker,
+		ast.NodeStrongA6kCloseMarker,
+		ast.NodeStrongU8eCloseMarker,
+		ast.NodeCodeSpanCloseMarker,
+		ast.NodeStrikethrough1CloseMarker,
+		ast.NodeStrikethrough2CloseMarker,
+		ast.NodeMathBlockCloseMarker,
+		ast.NodeInlineMathCloseMarker,
+		ast.NodeYamlFrontMatterCloseMarker,
+		ast.NodeMark1CloseMarker,
+		ast.NodeMark2CloseMarker,
+		ast.NodeTagCloseMarker,
+		ast.NodeSupCloseMarker,
+		ast.NodeSubCloseMarker:
+		return true
+	}
+	return false
+}
+
+// 是否是标识
+func isFlag(node *ast.Node) bool {
+	switch node.Type {
+	case ast.NodeParagraph:
+		return true
+	}
+	return false
+}
 
 // 处理根节点
 func (r *JSONRenderer) renderDocument(node *ast.Node, entering bool) ast.WalkStatus {
@@ -209,31 +267,302 @@ func (r *JSONRenderer) renderDocument(node *ast.Node, entering bool) ast.WalkSta
 	return ast.WalkContinue
 }
 
-// TODO 需要检验KramdownBlockIAL
-func (r *JSONRenderer) renderKramdownBlockIAL(node *ast.Node, entering bool) ast.WalkStatus {
+// 处理段落 - 标识
+func (r *JSONRenderer) renderParagraph(node *ast.Node, entering bool) ast.WalkStatus {
 	if entering {
-		if nil == node.Previous {
-			return ast.WalkContinue
-		}
-		id := r.NodeID(node.Previous)
-		if util.IsDocIAL(node.Tokens) {
-			id = r.Tree.ID
-		}
-		r.leaf(node.Type, "Block IAL\n{: "+id+"}", node)
+		r.openObj()
+		r.flag(node)
+		// TODO 判断下一个节点是不是Text
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
 	}
 	return ast.WalkContinue
 }
 
-func (r *JSONRenderer) renderKramdownSpanIAL(node *ast.Node, entering bool) ast.WalkStatus {
+// 处理文本 - "text"属性
+func (r *JSONRenderer) renderText(node *ast.Node, entering bool) ast.WalkStatus {
 	if entering {
-		if nil == node.Previous {
-			return ast.WalkContinue
-		}
-		id := r.NodeID(node.Previous)
-		r.leaf(node.Type,"Span IAL\n{: "+id+"}", node)
+		r.openObj()
+		r.val(node.Type, util.BytesToStr(node.Tokens))
+	} else {
+		r.closeObj(node)
+	}
+	return ast.WalkSkipChildren
+}
+
+// 处理行内代码根节点
+func (r *JSONRenderer) renderCodeSpan(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+// TODO 处理renderCodeSpanOpenMarker
+func (r *JSONRenderer) renderCodeSpanOpenMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+// 渲染行内代码
+func (r *JSONRenderer) renderCodeSpanContent(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.val(ast.NodeCodeSpan, util.BytesToStr(node.Tokens))
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
 	}
 	return ast.WalkContinue
 }
+
+// TODO 处理renderCodeSpanCloseMarker
+func (r *JSONRenderer) renderCodeSpanCloseMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderMathBlock(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderMathBlockOpenMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+// 解析数学块
+func (r *JSONRenderer) renderMathBlockContent(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.val(ast.NodeMathBlock,util.BytesToStr(node.Tokens))
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderMathBlockCloseMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderInlineMath(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderInlineMathOpenMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+// 解析行内数学公式
+func (r *JSONRenderer) renderInlineMathContent(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.val(ast.NodeInlineMath, util.BytesToStr(node.Tokens))
+	} else {
+		r.closeObj(node)
+	}
+	return ast.WalkSkipChildren
+}
+
+func (r *JSONRenderer) renderInlineMathCloseMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderEmAsteriskOpenMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderEmUnderscoreOpenMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+// 斜体标志存在
+func (r *JSONRenderer) renderEmphasis(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.flag(node)
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderEmAsteriskCloseMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderEmUnderscoreCloseMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderStrongA6kOpenMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderStrongU8eOpenMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+// 加粗标志存在
+func (r *JSONRenderer) renderStrong(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.flag(node)
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderStrongA6kCloseMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderStrongU8eCloseMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+// 引用标识存在 - flag
+func (r *JSONRenderer) renderBlockquote(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.flag(node)
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderBlockquoteMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+// 渲染标题
+func (r *JSONRenderer) renderHeading(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		h := "h" + headingLevel[node.HeadingLevel:node.HeadingLevel+1]
+		// 标题值为标题等级
+		r.val(node.Type, h)
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderHeadingC8hMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderHeadingID(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderList(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		list := "ul"
+		if 1 == node.ListData.Typ || (3 == node.ListData.Typ && 0 == node.ListData.BulletChar) {
+			list = "ol"
+		}
+		// 值为列表的类型
+		r.val(node.Type, list)
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+// TODO 修复可能的BUG
+func (r *JSONRenderer) renderListItem(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.flag(node)
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+// 分割线
+func (r *JSONRenderer) renderThematicBreak(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.leaf(node.Type, "hr", node)
+	}
+	return ast.WalkSkipChildren
+}
+
+
+// TODO 硬换行，与InlineHTML冲突
+func (r *JSONRenderer) renderHardBreak(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.leaf(node.Type, "br", node)
+	}
+	return ast.WalkSkipChildren
+}
+
+// \n换行
+func (r *JSONRenderer) renderSoftBreak(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.leaf(node.Type, "\n", node)
+	}
+	return ast.WalkSkipChildren
+}
+
+// 行内HTML
+func (r *JSONRenderer) renderInlineHTML(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		tokens := node.Tokens
+		if r.Option.Sanitize {
+			tokens = sanitize(tokens)
+		}
+		r.val(node.Type, util.BytesToStr(tokens))
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+//// TODO 需要检验KramdownBlockIAL
+//func (r *JSONRenderer) renderKramdownBlockIAL(node *ast.Node, entering bool) ast.WalkStatus {
+//	if entering {
+//		if nil == node.Previous {
+//			return ast.WalkContinue
+//		}
+//		id := r.NodeID(node.Previous)
+//		if util.IsDocIAL(node.Tokens) {
+//			id = r.Tree.ID
+//		}
+//		r.leaf(node.Type, "Block IAL\n{: "+id+"}", node)
+//	}
+//	return ast.WalkContinue
+//}
+//
+//func (r *JSONRenderer) renderKramdownSpanIAL(node *ast.Node, entering bool) ast.WalkStatus {
+//	if entering {
+//		if nil == node.Previous {
+//			return ast.WalkContinue
+//		}
+//		id := r.NodeID(node.Previous)
+//		r.leaf(node.Type,"Span IAL\n{: "+id+"}", node)
+//	}
+//	return ast.WalkContinue
+//}
 
 // TODO Mark是指？
 func (r *JSONRenderer) renderMark(node *ast.Node, entering bool) ast.WalkStatus {
@@ -333,30 +662,6 @@ func (r *JSONRenderer) renderFootnotesDef(node *ast.Node, entering bool) ast.Wal
 	if entering {
 		r.openObj()
 		r.val(node.Type, node.Text())
-		r.openChildren(node)
-	} else {
-		r.closeChildren(node)
-		r.closeObj(node)
-	}
-	return ast.WalkContinue
-}
-
-// 解析行内数学公式
-func (r *JSONRenderer) renderInlineMathContent(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		r.openObj()
-		r.val(ast.NodeInlineMath, util.BytesToStr(node.Tokens))
-	} else {
-		r.closeObj(node)
-	}
-	return ast.WalkSkipChildren
-}
-
-// 解析数学块
-func (r *JSONRenderer) renderMathBlockContent(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		r.openObj()
-		r.val(ast.NodeMathBlock,util.BytesToStr(node.Tokens))
 		r.openChildren(node)
 	} else {
 		r.closeChildren(node)
@@ -549,157 +854,12 @@ func (r *JSONRenderer) renderLink(node *ast.Node, entering bool) ast.WalkStatus 
 	return ast.WalkContinue
 }
 
+// TODO HTML块
 func (r *JSONRenderer) renderHTML(node *ast.Node, entering bool) ast.WalkStatus {
 	if entering {
 		r.leaf(node.Type, "HTML Block\n", node)
 	}
 	return ast.WalkSkipChildren
-}
-
-func (r *JSONRenderer) renderInlineHTML(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		r.openObj()
-		tokens := node.Tokens
-		if r.Option.Sanitize {
-			tokens = sanitize(tokens)
-		}
-		r.val(node.Type, util.BytesToStr(tokens))
-		r.openChildren(node)
-	} else {
-		r.closeChildren(node)
-		r.closeObj(node)
-	}
-	return ast.WalkContinue
-}
-
-func (r *JSONRenderer) renderParagraph(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		r.openObj()
-		r.flag(node)
-		r.openChildren(node)
-	} else {
-		r.closeChildren(node)
-		r.closeObj(node)
-	}
-	return ast.WalkContinue
-}
-
-func (r *JSONRenderer) renderText(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		text := util.BytesToStr(node.Tokens)
-		r.text(text)
-	}
-	return ast.WalkSkipChildren
-}
-
-func (r *JSONRenderer) renderCodeSpan(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		r.openObj()
-		r.flag(node)
-		r.openChildren(node)
-	} else {
-		r.closeChildren(node)
-		r.closeObj(node)
-	}
-	return ast.WalkContinue
-}
-
-// 渲染行内代码
-func (r *JSONRenderer) renderCodeSpanContent(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		r.openObj()
-		r.val(node.Type, util.BytesToStr(node.Tokens))
-		r.openChildren(node)
-	} else {
-		r.closeChildren(node)
-		r.closeObj(node)
-	}
-	return ast.WalkContinue
-}
-
-// 斜体标志存在
-func (r *JSONRenderer) renderEmphasis(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		r.openObj()
-		r.val(node.Type, "")
-		//r.flag(node)
-		r.openChildren(node)
-	} else {
-		r.closeChildren(node)
-		r.closeObj(node)
-	}
-	return ast.WalkContinue
-}
-
-// 加粗标志存在
-func (r *JSONRenderer) renderStrong(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		r.openObj()
-		r.flag(node)
-		r.openChildren(node)
-	} else {
-		r.closeChildren(node)
-		r.closeObj(node)
-	}
-	return ast.WalkContinue
-}
-
-// 引用标识存在
-func (r *JSONRenderer) renderBlockquote(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		r.openObj()
-		r.val(node.Type, "")
-		r.openChildren(node)
-	} else {
-		r.closeChildren(node)
-		r.closeObj(node)
-	}
-	return ast.WalkContinue
-}
-
-// 标题存在，返回标题等级
-func (r *JSONRenderer) renderHeading(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		r.openObj()
-		h := "h" + headingLevel[node.HeadingLevel:node.HeadingLevel+1]
-		// 标题值为标题等级
-		r.val(node.Type, h)
-		r.openChildren(node)
-	} else {
-		r.closeChildren(node)
-		r.closeObj(node)
-	}
-	return ast.WalkContinue
-}
-
-func (r *JSONRenderer) renderList(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		r.openObj()
-		list := "ul"
-		if 1 == node.ListData.Typ || (3 == node.ListData.Typ && 0 == node.ListData.BulletChar) {
-			list = "ol"
-		}
-		// 值为列表的类型
-		r.val(node.Type, list)
-		r.openChildren(node)
-	} else {
-		r.closeChildren(node)
-		r.closeObj(node)
-	}
-	return ast.WalkContinue
-}
-
-// TODO 修复可能的BUG
-func (r *JSONRenderer) renderListItem(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		r.openObj()
-		r.val(node.Type, node.Text())
-		r.openChildren(node)
-	} else {
-		r.closeChildren(node)
-		r.closeObj(node)
-	}
-	return ast.WalkContinue
 }
 
 func (r *JSONRenderer) renderTaskListItemMarker(node *ast.Node, entering bool) ast.WalkStatus {
@@ -717,30 +877,6 @@ func (r *JSONRenderer) renderTaskListItemMarker(node *ast.Node, entering bool) a
 		r.closeObj(node)
 	}
 	return ast.WalkContinue
-}
-
-// 分割线
-func (r *JSONRenderer) renderThematicBreak(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		r.leaf(node.Type, "hr", node)
-	}
-	return ast.WalkSkipChildren
-}
-
-// TODO 硬换行，与InlineHTML冲突
-func (r *JSONRenderer) renderHardBreak(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		r.leaf(node.Type, "br", node)
-	}
-	return ast.WalkSkipChildren
-}
-
-// \n换行
-func (r *JSONRenderer) renderSoftBreak(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		r.leaf(node.Type, "\n", node)
-	}
-	return ast.WalkSkipChildren
 }
 
 // TODO 重新考虑处理代码内容和语言类型
@@ -773,9 +909,9 @@ func (r *JSONRenderer) val(nodeType ast.NodeType , val string) {
 }
 
 // 写入如果节点是Text
-func (r *JSONRenderer) text(val string) {
-	r.WriteString(",\"text\":\"" + val + "\"")
-}
+//func (r *JSONRenderer) text(val string) {
+//	r.WriteString(",\"text\":\"" + val + "\"")
+//}
 
 func (r *JSONRenderer) flag(node *ast.Node) {
 	//if !checkIfFlag(node.Parent.Type) {
@@ -802,10 +938,12 @@ func (r *JSONRenderer) openObj() {
 	r.WriteByte('{')
 }
 
-// 关闭对象
+// TODO BUG 关闭对象
 func (r *JSONRenderer) closeObj(node *ast.Node) {
 	r.WriteByte('}')
-	r.comma()
+	if !r.ignore(node.Next) {
+		r.comma()
+	}
 }
 
 // 打开子节点
@@ -825,4 +963,9 @@ func (r *JSONRenderer) closeChildren(node *ast.Node) {
 // 逗号
 func (r *JSONRenderer) comma() {
 	r.WriteString(",")
+}
+
+// 忽略函数
+func (r *JSONRenderer) ignore(node *ast.Node) bool {
+	return nil == node || isOpenMarker(node) || isCloseMarker(node)
 }

--- a/render/json_renderer.go
+++ b/render/json_renderer.go
@@ -70,40 +70,40 @@ func NewJSONRenderer(tree *parse.Tree) Renderer {
 	ret.RendererFuncs[ast.NodeSoftBreak] = ret.renderSoftBreak
 	ret.RendererFuncs[ast.NodeHTMLBlock] = ret.renderHTML
 	ret.RendererFuncs[ast.NodeInlineHTML] = ret.renderInlineHTML
-	//ret.RendererFuncs[ast.NodeLink] = ret.renderLink
+	ret.RendererFuncs[ast.NodeLink] = ret.renderLink
 	//ret.RendererFuncs[ast.NodeImage] = ret.renderImage
-	//ret.RendererFuncs[ast.NodeBang] = ret.renderBang
-	//ret.RendererFuncs[ast.NodeOpenBracket] = ret.renderOpenBracket
-	//ret.RendererFuncs[ast.NodeCloseBracket] = ret.renderCloseBracket
-	//ret.RendererFuncs[ast.NodeOpenParen] = ret.renderOpenParen
-	//ret.RendererFuncs[ast.NodeCloseParen] = ret.renderCloseParen
-	//ret.RendererFuncs[ast.NodeOpenBrace] = ret.renderOpenBrace
-	//ret.RendererFuncs[ast.NodeCloseBrace] = ret.renderCloseBrace
-	//ret.RendererFuncs[ast.NodeLinkText] = ret.renderLinkText
-	//ret.RendererFuncs[ast.NodeLinkSpace] = ret.renderLinkSpace
-	//ret.RendererFuncs[ast.NodeLinkDest] = ret.renderLinkDest
-	//ret.RendererFuncs[ast.NodeLinkTitle] = ret.renderLinkTitle
-	//ret.RendererFuncs[ast.NodeStrikethrough] = ret.renderStrikethrough
-	//ret.RendererFuncs[ast.NodeStrikethrough1OpenMarker] = ret.renderStrikethrough1OpenMarker
-	//ret.RendererFuncs[ast.NodeStrikethrough1CloseMarker] = ret.renderStrikethrough1CloseMarker
-	//ret.RendererFuncs[ast.NodeStrikethrough2OpenMarker] = ret.renderStrikethrough2OpenMarker
-	//ret.RendererFuncs[ast.NodeStrikethrough2CloseMarker] = ret.renderStrikethrough2CloseMarker
+	ret.RendererFuncs[ast.NodeBang] = ret.renderBang
+	ret.RendererFuncs[ast.NodeOpenBracket] = ret.renderOpenBracket
+	ret.RendererFuncs[ast.NodeCloseBracket] = ret.renderCloseBracket
+	ret.RendererFuncs[ast.NodeOpenParen] = ret.renderOpenParen
+	ret.RendererFuncs[ast.NodeCloseParen] = ret.renderCloseParen
+	ret.RendererFuncs[ast.NodeOpenBrace] = ret.renderOpenBrace
+	ret.RendererFuncs[ast.NodeCloseBrace] = ret.renderCloseBrace
+	ret.RendererFuncs[ast.NodeLinkText] = ret.renderLinkText
+	ret.RendererFuncs[ast.NodeLinkSpace] = ret.renderLinkSpace
+	ret.RendererFuncs[ast.NodeLinkDest] = ret.renderLinkDest
+	ret.RendererFuncs[ast.NodeLinkTitle] = ret.renderLinkTitle
+	ret.RendererFuncs[ast.NodeStrikethrough] = ret.renderStrikethrough
+	ret.RendererFuncs[ast.NodeStrikethrough1OpenMarker] = ret.renderStrikethrough1OpenMarker
+	ret.RendererFuncs[ast.NodeStrikethrough1CloseMarker] = ret.renderStrikethrough1CloseMarker
+	ret.RendererFuncs[ast.NodeStrikethrough2OpenMarker] = ret.renderStrikethrough2OpenMarker
+	ret.RendererFuncs[ast.NodeStrikethrough2CloseMarker] = ret.renderStrikethrough2CloseMarker
 	//ret.RendererFuncs[ast.NodeTaskListItemMarker] = ret.renderTaskListItemMarker
-	//ret.RendererFuncs[ast.NodeTable] = ret.renderTable
-	//ret.RendererFuncs[ast.NodeTableHead] = ret.renderTableHead
-	//ret.RendererFuncs[ast.NodeTableRow] = ret.renderTableRow
-	//ret.RendererFuncs[ast.NodeTableCell] = ret.renderTableCell
-	//ret.RendererFuncs[ast.NodeEmoji] = ret.renderEmoji
-	//ret.RendererFuncs[ast.NodeEmojiUnicode] = ret.renderEmojiUnicode
-	//ret.RendererFuncs[ast.NodeEmojiImg] = ret.renderEmojiImg
-	//ret.RendererFuncs[ast.NodeEmojiAlias] = ret.renderEmojiAlias
+	ret.RendererFuncs[ast.NodeTable] = ret.renderTable
+	ret.RendererFuncs[ast.NodeTableHead] = ret.renderTableHead
+	ret.RendererFuncs[ast.NodeTableRow] = ret.renderTableRow
+	ret.RendererFuncs[ast.NodeTableCell] = ret.renderTableCell
+	ret.RendererFuncs[ast.NodeEmoji] = ret.renderEmoji
+	ret.RendererFuncs[ast.NodeEmojiUnicode] = ret.renderEmojiUnicode
+	ret.RendererFuncs[ast.NodeEmojiImg] = ret.renderEmojiImg
+	ret.RendererFuncs[ast.NodeEmojiAlias] = ret.renderEmojiAlias
 	//ret.RendererFuncs[ast.NodeFootnotesDefBlock] = ret.renderFootnotesDefBlock
 	//ret.RendererFuncs[ast.NodeFootnotesDef] = ret.renderFootnotesDef
 	//ret.RendererFuncs[ast.NodeFootnotesRef] = ret.renderFootnotesRef
 	//ret.RendererFuncs[ast.NodeToC] = ret.renderToC
 	//ret.RendererFuncs[ast.NodeBackslash] = ret.renderBackslash
 	//ret.RendererFuncs[ast.NodeBackslashContent] = ret.renderBackslashContent
-	//ret.RendererFuncs[ast.NodeHTMLEntity] = ret.renderHtmlEntity
+	ret.RendererFuncs[ast.NodeHTMLEntity] = ret.renderHtmlEntity
 	//ret.RendererFuncs[ast.NodeYamlFrontMatter] = ret.renderYamlFrontMatter
 	//ret.RendererFuncs[ast.NodeYamlFrontMatterOpenMarker] = ret.renderYamlFrontMatterOpenMarker
 	//ret.RendererFuncs[ast.NodeYamlFrontMatterContent] = ret.renderYamlFrontMatterContent
@@ -538,6 +538,236 @@ func (r *JSONRenderer) renderInlineHTML(node *ast.Node, entering bool) ast.WalkS
 	return ast.WalkContinue
 }
 
+// 处理链接
+func (r *JSONRenderer) renderLink(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		dest := node.ChildByType(ast.NodeLinkDest)
+		destTokens := dest.Tokens
+		destTokens = r.Tree.Context.LinkPath(destTokens)
+		if title := node.ChildByType(ast.NodeLinkTitle); nil != title && nil != title.Tokens {
+			r.val(node.Type, util.BytesToStr(title.Tokens) + "|" + util.BytesToStr(destTokens))
+		} else {
+			r.val(node.Type, util.BytesToStr(destTokens))
+		}
+	} else {
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+// TODO 处理图片
+func (r *JSONRenderer) renderImage(node *ast.Node, entering bool) ast.WalkStatus {
+	//// TODO 处理图片渲染
+	//if entering {
+	//	r.openObj()
+	//	if 0 == r.DisableTags {
+	//		destTokens := node.ChildByType(ast.NodeLinkDest).Tokens
+	//		// 图片的地址
+	//		destTokens = r.Tree.Context.LinkPath(destTokens)
+	//	}
+	//	r.DisableTags++
+	//	return ast.WalkContinue
+	//} else {
+	//	r.closeObj(node)
+	//}
+	//// 获取alt?
+	////
+	//r.DisableTags--
+	//if 0 == r.DisableTags {
+	//	if title := node.ChildByType(ast.NodeLinkTitle); nil != title && nil != title.Tokens {
+	//		// title的值
+	//		//fmt.Println(util.BytesToStr(title.Tokens))
+	//		//r.Write(html.EscapeHTML(title.Tokens))
+	//	}
+	//	ial := r.NodeAttrsStr(node)
+	//	if "" != ial {
+	//		fmt.Println(ial)
+	//		//r.WriteString(" " + ial)
+	//	}
+	//}
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderBang(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderOpenBracket(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderCloseBracket(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderOpenParen(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderCloseParen(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderOpenBrace(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderCloseBrace(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderLinkTitle(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderLinkDest(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderLinkSpace(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderLinkText(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		var tokens []byte
+		if r.Option.AutoSpace {
+			tokens = r.Space(node.Tokens)
+		} else {
+			tokens = node.Tokens
+		}
+		r.WriteString(",\"text\":" + util.BytesToStr(tokens) + "\"")
+	}
+	return ast.WalkContinue
+}
+
+// 删除线标识
+func (r *JSONRenderer) renderStrikethrough(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.flag(node)
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderStrikethrough1OpenMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderStrikethrough1CloseMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderStrikethrough2OpenMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderStrikethrough2CloseMarker(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderTableCell(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		var align string
+		switch node.TableCellAlign {
+		case 1:
+			align = "left"
+		case 2:
+			align = "center"
+		case 3:
+			align = "right"
+		default:
+			align = "left"
+		}
+		r.openObj()
+		r.val(node.Type, align)
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+// 表格新行标识
+func (r *JSONRenderer) renderTableRow(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.flag(node)
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+// 表头标识
+func (r *JSONRenderer) renderTableHead(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.flag(node)
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+// 表格标识
+func (r *JSONRenderer) renderTable(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.flag(node)
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
+func (r *JSONRenderer) renderEmojiImg(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.leaf(node.Type, util.BytesToStr(node.Tokens), node)
+	}
+	return ast.WalkSkipChildren
+}
+
+func (r *JSONRenderer) renderEmojiUnicode(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.leaf(node.Type, util.BytesToStr(node.Tokens), node)
+	}
+	return ast.WalkSkipChildren
+}
+
+func (r *JSONRenderer) renderEmojiAlias(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkSkipChildren
+}
+
+func (r *JSONRenderer) renderEmoji(node *ast.Node, entering bool) ast.WalkStatus {
+	return ast.WalkContinue
+}
+
+// HTML实体符号处理
+func (r *JSONRenderer) renderHtmlEntity(node *ast.Node, entering bool) ast.WalkStatus {
+	if entering {
+		r.openObj()
+		r.val(node.Type, util.BytesToStr(node.Tokens))
+		r.openChildren(node)
+	} else {
+		r.closeChildren(node)
+		r.closeObj(node)
+	}
+	return ast.WalkContinue
+}
+
 //// TODO 需要检验KramdownBlockIAL
 //func (r *JSONRenderer) renderKramdownBlockIAL(node *ast.Node, entering bool) ast.WalkStatus {
 //	if entering {
@@ -620,19 +850,6 @@ func (r *JSONRenderer) renderYamlFrontMatter(node *ast.Node, entering bool) ast.
 	return ast.WalkSkipChildren
 }
 
-// HTML实体符号处理
-func (r *JSONRenderer) renderHtmlEntity(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		r.openObj()
-		r.val(node.Type, util.BytesToStr(node.Tokens))
-		r.openChildren(node)
-	} else {
-		r.closeChildren(node)
-		r.closeObj(node)
-	}
-	return ast.WalkContinue
-}
-
 func (r *JSONRenderer) renderBackslashContent(node *ast.Node, entering bool) ast.WalkStatus {
 	return ast.WalkSkipChildren
 }
@@ -659,190 +876,6 @@ func (r *JSONRenderer) renderFootnotesRef(node *ast.Node, entering bool) ast.Wal
 }
 
 func (r *JSONRenderer) renderFootnotesDef(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		r.openObj()
-		r.val(node.Type, node.Text())
-		r.openChildren(node)
-	} else {
-		r.closeChildren(node)
-		r.closeObj(node)
-	}
-	return ast.WalkContinue
-}
-
-func (r *JSONRenderer) renderEmojiImg(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		r.leaf(node.Type, util.BytesToStr(node.Tokens), node)
-	}
-	return ast.WalkSkipChildren
-}
-
-func (r *JSONRenderer) renderEmojiUnicode(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		r.leaf(node.Type, util.BytesToStr(node.Tokens), node)
-	}
-	return ast.WalkSkipChildren
-}
-
-func (r *JSONRenderer) renderEmojiAlias(node *ast.Node, entering bool) ast.WalkStatus {
-	return ast.WalkSkipChildren
-}
-
-func (r *JSONRenderer) renderEmoji(node *ast.Node, entering bool) ast.WalkStatus {
-	return ast.WalkContinue
-}
-
-// TODO 处理表格渲染
-// TODO Cell渲染函数才能拿到对齐
-func (r *JSONRenderer) renderTableCell(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		var align string
-		switch node.TableCellAlign {
-		case 1:
-			align = "left"
-		case 2:
-			align = "center"
-		case 3:
-			align = "right"
-		default:
-			align = "left"
-		}
-		r.openObj()
-		r.val(node.Type, align)
-		r.openChildren(node)
-	} else {
-		r.closeChildren(node)
-		r.closeObj(node)
-	}
-	return ast.WalkContinue
-}
-
-// 表格新行标识
-func (r *JSONRenderer) renderTableRow(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		r.openObj()
-		r.val(node.Type, "")
-		r.openChildren(node)
-	} else {
-		r.closeChildren(node)
-		r.closeObj(node)
-	}
-	return ast.WalkContinue
-}
-
-// 表头标识
-func (r *JSONRenderer) renderTableHead(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		r.openObj()
-		r.val(node.Type, "")
-		r.openChildren(node)
-	} else {
-		r.closeChildren(node)
-		r.closeObj(node)
-	}
-	return ast.WalkContinue
-}
-
-// 表格标识
-func (r *JSONRenderer) renderTable(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		r.openObj()
-		r.val(node.Type, "")
-		r.openChildren(node)
-	} else {
-		r.closeChildren(node)
-		r.closeObj(node)
-	}
-	return ast.WalkContinue
-}
-
-// 删除线标识
-func (r *JSONRenderer) renderStrikethrough(node *ast.Node, entering bool) ast.WalkStatus {
-	if entering {
-		r.openObj()
-		r.val(node.Type, "")
-		r.openChildren(node)
-	} else {
-		r.closeChildren(node)
-		r.closeObj(node)
-	}
-	return ast.WalkContinue
-}
-
-func (r *JSONRenderer) renderImage(node *ast.Node, entering bool) ast.WalkStatus {
-	// TODO 处理图片渲染
-	//if entering {
-	//	if 0 == r.DisableTags {
-	//		r.WriteString("<img src=\"")
-	//		destTokens := node.ChildByType(ast.NodeLinkDest).Tokens
-	//		destTokens = r.Tree.Context.LinkPath(destTokens)
-	//		if "" != r.Option.ImageLazyLoading {
-	//			r.Write(html.EscapeHTML(util.StrToBytes(r.Option.ImageLazyLoading)))
-	//			r.WriteString("\" data-src=\"")
-	//		}
-	//		r.Write(html.EscapeHTML(destTokens))
-	//		r.WriteString("\" alt=\"")
-	//	}
-	//	r.DisableTags++
-	//	return ast.WalkContinue
-	//}
-	//
-	//r.DisableTags--
-	//if 0 == r.DisableTags {
-	//	r.WriteByte(lex.ItemDoublequote)
-	//	if title := node.ChildByType(ast.NodeLinkTitle); nil != title && nil != title.Tokens {
-	//		r.WriteString(" title=\"")
-	//		r.Write(html.EscapeHTML(title.Tokens))
-	//		r.WriteByte(lex.ItemDoublequote)
-	//	}
-	//	ial := r.NodeAttrsStr(node)
-	//	if "" != ial {
-	//		r.WriteString(" " + ial)
-	//	}
-	//	r.WriteString(" />")
-	//
-	//	if r.Option.Sanitize {
-	//		buf := r.Writer.Bytes()
-	//		idx := bytes.LastIndex(buf, []byte("<img src="))
-	//		imgBuf := buf[idx:]
-	//		if r.Option.Sanitize {
-	//			imgBuf = sanitize(imgBuf)
-	//		}
-	//		r.Writer.Truncate(idx)
-	//		r.Writer.Write(imgBuf)
-	//	}
-	//}
-	//return ast.WalkContinue
-	if entering {
-		r.openObj()
-		r.val(node.Type, node.Text())
-		r.openChildren(node)
-	} else {
-		r.closeChildren(node)
-		r.closeObj(node)
-	}
-	return ast.WalkContinue
-}
-
-func (r *JSONRenderer) renderLink(node *ast.Node, entering bool) ast.WalkStatus {
-    // TODO 处理链接渲染
-	//if entering {
-	//	r.LinkTextAutoSpacePrevious(node)
-	//
-	//	dest := node.ChildByType(ast.NodeLinkDest)
-	//	destTokens := dest.Tokens
-	//	destTokens = r.Tree.Context.LinkPath(destTokens)
-	//	attrs := [][]string{{"href", util.BytesToStr(html.EscapeHTML(destTokens))}}
-	//	if title := node.ChildByType(ast.NodeLinkTitle); nil != title && nil != title.Tokens {
-	//		attrs = append(attrs, []string{"title", util.BytesToStr(html.EscapeHTML(title.Tokens))})
-	//	}
-	//	r.Tag("a", attrs, false)
-	//} else {
-	//	r.Tag("/a", nil, false)
-	//
-	//	r.LinkTextAutoSpaceNext(node)
-	//}
-	//return ast.WalkContinue
 	if entering {
 		r.openObj()
 		r.val(node.Type, node.Text())

--- a/test/json_renderer_test.go
+++ b/test/json_renderer_test.go
@@ -1,0 +1,28 @@
+// Lute - 一款对中文语境优化的 Markdown 引擎，支持 Go 和 JavaScript
+// Copyright (c) 2019-present, b3log.org
+//
+// Lute is licensed under Mulan PSL v2.
+// You can use this software according to the terms and conditions of the Mulan PSL v2.
+// You may obtain a copy of Mulan PSL v2 at:
+//         http://license.coscl.org.cn/MulanPSL2
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+// See the Mulan PSL v2 for more details.
+
+package test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/88250/lute"
+)
+
+var JSONRendererTest = "**`小小的文本测试`**"
+
+func TestJSONRenderer(t *testing.T) {
+	luteEngine := lute.New()
+	luteEngine.KramdownIAL = false
+
+	jsonStr := luteEngine.RenderJSON(JSONRendererTest)
+	fmt.Println(jsonStr)
+}

--- a/test/json_renderer_test.go
+++ b/test/json_renderer_test.go
@@ -11,7 +11,6 @@
 package test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/88250/lute"
@@ -19,35 +18,35 @@ import (
 
 var JSONRendererTests = []parseTest{
 	{"测试普通文本","普通文本测试","[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Text\",\"value\":\"普通文本测试\"}]}]"},
-	{"测试行内代码", "`console.log(\"Hello World\")`", "[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"CodeSpan\",\"value\":\"console.log(\\\"Hello World\\\")\"}]}]\n"},
+	{"测试行内代码", "`console.log(\"Hello World\")`", "[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"CodeSpan\",\"value\":\"console.log(\\\"Hello World\\\")\"}]}]"},
 	{"测试代码块", "```js\nconsole.log(\"Hello World\")\n```\n", "[{\"type\":\"CodeBlock\",\"value\":\"console.log(\\\"Hello World\\\")\\n\",\"language\":\"js\"}]"},
 	{"测试数学块", "$$\na + b = c\n$$\n", "[{\"type\":\"MathBlock\",\"value\":\"a + b = c\"}]"},
-	{"测试行内数学公式", "$a + b = c$", "[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"InlineMath\",\"value\":\"a + b = c\"}]}]\n"},
-	{"测试斜体", "*测试斜体*", "[{\"flag\":\"Paragraph\",\"children\":[{\"flag\":\"Emphasis\",\"children\":[{\"type\":\"Text\",\"value\":\"测试斜体\"}]}]}]\n"},
-	{"测试加粗", "**测试粗体**", "[{\"flag\":\"Paragraph\",\"children\":[{\"flag\":\"Strong\",\"children\":[{\"type\":\"Text\",\"value\":\"测试粗体\"}]}]}]\n"},
-	{"测试引用块", "> 测试引用块", "[{\"flag\":\"Blockquote\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Text\",\"value\":\"测试引用块\"}]}]}]\n"},
-	{"测试标题", "# 一级标题", "[{\"type\":\"Heading\",\"value\":\"h1\",\"children\":[{\"type\":\"Text\",\"value\":\"一级标题\"}]}]\n"},
-	{"测试无序列表", "- item1\n- item2\n- item3\n", "[{\"type\":\"List\",\"value\":\"ul\",\"children\":[{\"flag\":\"ListItem\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Text\",\"value\":\"item1\"}]}]},{\"flag\":\"ListItem\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Text\",\"value\":\"item2\"}]}]},{\"flag\":\"ListItem\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Text\",\"value\":\"item3\"}]}]}]}]\n"},
-	{"测试有序列表", "1. item1\n2. item2\n3. item3\n", "[{\"type\":\"List\",\"value\":\"ol\",\"children\":[{\"flag\":\"ListItem\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Text\",\"value\":\"item1\"}]}]},{\"flag\":\"ListItem\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Text\",\"value\":\"item2\"}]}]},{\"flag\":\"ListItem\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Text\",\"value\":\"item3\"}]}]}]}]\n"},
-	//{"测试分割线", "---", ""},
-	//{"测试软换行", "测试换行\\n", ""},
-	{"测试HTML块", "<div>\nHTML块\n</div>\n", "[{\"type\":\"HTMLBlock\",\"value\":\"<div>\\nHTML块\\n</div>\"}]\n"},
-	{"测试行内HTML", "<a>行内HTML</a>", "[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"InlineHTML\",\"value\":\"<a>\"},{\"type\":\"Text\",\"value\":\"行内HTML\"},{\"type\":\"InlineHTML\",\"value\":\"</a>\"}]}]\n"},
-	{"测试链接", "[链接文本](链接)", "[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Link\",\"value\":\"%E9%93%BE%E6%8E%A5\",\"title\":\"链接文本\"}]}]\n"},
-	{"测试图片", "![图片文本](图片链接)", "[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Image\",\"value\":\"%E5%9B%BE%E7%89%87%E9%93%BE%E6%8E%A5\",\"title\":\"图片文本\"}]}]\n"},
-	{"测试删除线", "~~删除线~~", "[{\"flag\":\"Paragraph\",\"children\":[{\"flag\":\"Strikethrough\",\"children\":[{\"type\":\"Text\",\"value\":\"删除线\"}]}]}]\n"},
-	{"测试TaskList", "- [X] item1\n- [ ] item2\n- [X] item3\n", "[{\"type\":\"List\",\"value\":\"ul\",\"children\":[{\"flag\":\"ListItem\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"TaskListItemMarker\",\"value\":\"true\"},{\"type\":\"Text\",\"value\":\" item1\"}]}]},{\"flag\":\"ListItem\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"TaskListItemMarker\",\"value\":\"false\"},{\"type\":\"Text\",\"value\":\" item2\"}]}]},{\"flag\":\"ListItem\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"TaskListItemMarker\",\"value\":\"true\"},{\"type\":\"Text\",\"value\":\" item3\"}]}]}]}]\n"},
-	{"测试表格", "| 表头 | 标题 |\n| --- | --- |\n| item1 | item2 |\n| item3 | item4 |\n", "[{\"flag\":\"Table\",\"children\":[{\"flag\":\"TableHead\",\"children\":[{\"flag\":\"TableRow\",\"children\":[{\"type\":\"TableCell\",\"value\":\"left\",\"children\":[{\"type\":\"Text\",\"value\":\"表头\"}]},{\"type\":\"TableCell\",\"value\":\"left\",\"children\":[{\"type\":\"Text\",\"value\":\"标题\"}]}]}]},{\"flag\":\"TableRow\",\"children\":[{\"type\":\"TableCell\",\"value\":\"left\",\"children\":[{\"type\":\"Text\",\"value\":\"item1\"}]},{\"type\":\"TableCell\",\"value\":\"left\",\"children\":[{\"type\":\"Text\",\"value\":\"item2\"}]}]},{\"flag\":\"TableRow\",\"children\":[{\"type\":\"TableCell\",\"value\":\"left\",\"children\":[{\"type\":\"Text\",\"value\":\"item3\"}]},{\"type\":\"TableCell\",\"value\":\"left\",\"children\":[{\"type\":\"Text\",\"value\":\"item4\"}]}]}]}]\n"},
-	{"测试emoji", ":cn:", "[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"EmojiUnicode\",\"value\":\"🇨🇳\"}]}]\n"},
+	{"测试行内数学公式", "$a + b = c$", "[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"InlineMath\",\"value\":\"a + b = c\"}]}]"},
+	{"测试斜体", "*测试斜体*", "[{\"flag\":\"Paragraph\",\"children\":[{\"flag\":\"Emphasis\",\"children\":[{\"type\":\"Text\",\"value\":\"测试斜体\"}]}]}]"},
+	{"测试加粗", "**测试粗体**", "[{\"flag\":\"Paragraph\",\"children\":[{\"flag\":\"Strong\",\"children\":[{\"type\":\"Text\",\"value\":\"测试粗体\"}]}]}]"},
+	{"测试引用块", "> 测试引用块", "[{\"flag\":\"Blockquote\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Text\",\"value\":\"测试引用块\"}]}]}]"},
+	{"测试标题", "# 一级标题", "[{\"type\":\"Heading\",\"value\":\"h1\",\"children\":[{\"type\":\"Text\",\"value\":\"一级标题\"}]}]"},
+	{"测试无序列表", "- item1\n- item2\n- item3\n", "[{\"type\":\"List\",\"value\":\"ul\",\"children\":[{\"flag\":\"ListItem\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Text\",\"value\":\"item1\"}]}]},{\"flag\":\"ListItem\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Text\",\"value\":\"item2\"}]}]},{\"flag\":\"ListItem\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Text\",\"value\":\"item3\"}]}]}]}]"},
+	{"测试有序列表", "1. item1\n2. item2\n3. item3\n", "[{\"type\":\"List\",\"value\":\"ol\",\"children\":[{\"flag\":\"ListItem\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Text\",\"value\":\"item1\"}]}]},{\"flag\":\"ListItem\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Text\",\"value\":\"item2\"}]}]},{\"flag\":\"ListItem\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Text\",\"value\":\"item3\"}]}]}]}]"},
+	{"测试分割线", "***", "[{\"type\":\"ThematicBreak\",\"value\":\"hr\"}]"},
+	{"测试软换行", "测试换行\\n", "[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Text\",\"value\":\"测试换行\\\\n\"}]}]"},
+	{"测试HTML块", "<div>\nHTML块\n</div>\n", "[{\"type\":\"HTMLBlock\",\"value\":\"<div>\\nHTML块\\n</div>\"}]"},
+	{"测试行内HTML", "<a>行内HTML</a>", "[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"InlineHTML\",\"value\":\"<a>\"},{\"type\":\"Text\",\"value\":\"行内HTML\"},{\"type\":\"InlineHTML\",\"value\":\"</a>\"}]}]"},
+	{"测试链接", "[链接文本](链接)", "[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Link\",\"value\":\"%E9%93%BE%E6%8E%A5\",\"title\":\"链接文本\"}]}]"},
+	{"测试图片", "![图片文本](图片链接)", "[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Image\",\"value\":\"%E5%9B%BE%E7%89%87%E9%93%BE%E6%8E%A5\",\"title\":\"图片文本\"}]}]"},
+	{"测试删除线", "~~删除线~~", "[{\"flag\":\"Paragraph\",\"children\":[{\"flag\":\"Strikethrough\",\"children\":[{\"type\":\"Text\",\"value\":\"删除线\"}]}]}]"},
+	{"测试TaskList", "- [X] item1\n- [ ] item2\n- [X] item3\n", "[{\"type\":\"List\",\"value\":\"ul\",\"children\":[{\"flag\":\"ListItem\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"TaskListItemMarker\",\"value\":\"true\"},{\"type\":\"Text\",\"value\":\" item1\"}]}]},{\"flag\":\"ListItem\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"TaskListItemMarker\",\"value\":\"false\"},{\"type\":\"Text\",\"value\":\" item2\"}]}]},{\"flag\":\"ListItem\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"TaskListItemMarker\",\"value\":\"true\"},{\"type\":\"Text\",\"value\":\" item3\"}]}]}]}]"},
+	{"测试表格", "| 表头 | 标题 |\n| --- | --- |\n| item1 | item2 |\n| item3 | item4 |\n", "[{\"flag\":\"Table\",\"children\":[{\"flag\":\"TableHead\",\"children\":[{\"flag\":\"TableRow\",\"children\":[{\"type\":\"TableCell\",\"value\":\"left\",\"children\":[{\"type\":\"Text\",\"value\":\"表头\"}]},{\"type\":\"TableCell\",\"value\":\"left\",\"children\":[{\"type\":\"Text\",\"value\":\"标题\"}]}]}]},{\"flag\":\"TableRow\",\"children\":[{\"type\":\"TableCell\",\"value\":\"left\",\"children\":[{\"type\":\"Text\",\"value\":\"item1\"}]},{\"type\":\"TableCell\",\"value\":\"left\",\"children\":[{\"type\":\"Text\",\"value\":\"item2\"}]}]},{\"flag\":\"TableRow\",\"children\":[{\"type\":\"TableCell\",\"value\":\"left\",\"children\":[{\"type\":\"Text\",\"value\":\"item3\"}]},{\"type\":\"TableCell\",\"value\":\"left\",\"children\":[{\"type\":\"Text\",\"value\":\"item4\"}]}]}]}]"},
+	{"测试emoji", ":cn:", "[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"EmojiUnicode\",\"value\":\"🇨🇳\"}]}]"},
 	{"测试HTML实体符号", "&copy;", "[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"HTMLEntity\",\"value\":\"©\"}]}]"},
 	{"测试yaml", "---\nyaml测试\n---\n", "[{\"type\":\"YamlFrontMatter\",\"value\":\"yaml测试\"}]"},
-	//{"测试块引用", "((id \"内容块引用\")", ""},
-	{"测试高亮", "==高亮==", "[{\"flag\":\"Paragraph\",\"children\":[{\"flag\":\"Mark\",\"children\":[{\"type\":\"Text\",\"value\":\"高亮\"}]}]}]\n"},
+	{"测试块引用", "((20200817123136-in6y5m1 \"内容块引用\"))", "[{\"flag\":\"Paragraph\",\"children\":[{\"flag\":\"BlockRef\",\"children\":[{\"type\":\"Text\",\"value\":\"内容块引用\"}]}]}]"},
+	{"测试高亮", "==高亮==", "[{\"flag\":\"Paragraph\",\"children\":[{\"flag\":\"Mark\",\"children\":[{\"type\":\"Text\",\"value\":\"高亮\"}]}]}]"},
 	{"测试上标", "^上标^", "[{\"flag\":\"Paragraph\",\"children\":[{\"flag\":\"Sup\",\"children\":[{\"type\":\"Text\",\"value\":\"上标\"}]}]}]"},
-	{"测试下标", "~下标~", "[{\"flag\":\"Paragraph\",\"children\":[{\"flag\":\"Sub\",\"children\":[{\"type\":\"Text\",\"value\":\"下标\"}]}]}]\n"},
-	{"测试内容块查询嵌入", "!{{ SELECT * FROM blocks WHERE content LIKE '%待办%' }}", "[{\"type\":\"BlockQueryEmbed\",\"value\":\"SELECT * FROM blocks WHERE content LIKE \\'%待办%\\'\"},]\n"},
-	{"测试内容块嵌入节点", "!((id \"text\"))", "[{\"type\":\"BlockEmbed\",\"value\":\"text\"}]\n"},
-	{"测试标签", "#标签测试#", "[{\"flag\":\"Paragraph\",\"children\":[{\"flag\":\"Tag\",\"children\":[{\"type\":\"Text\",\"value\":\"标签测试\"}]}]}]\n"},
+	{"测试下标", "~下标~", "[{\"flag\":\"Paragraph\",\"children\":[{\"flag\":\"Sub\",\"children\":[{\"type\":\"Text\",\"value\":\"下标\"}]}]}]"},
+	{"测试内容块查询嵌入", "!{{ SELECT * FROM blocks WHERE content LIKE '%待办%' }}", "[{\"type\":\"BlockQueryEmbed\",\"value\":\"SELECT * FROM blocks WHERE content LIKE \\'%待办%\\'\"},]"},
+	{"测试内容块嵌入节点", "!((id \"text\"))", "[{\"type\":\"BlockEmbed\",\"value\":\"text\"}]"},
+	{"测试标签", "#标签测试#", "[{\"flag\":\"Paragraph\",\"children\":[{\"flag\":\"Tag\",\"children\":[{\"type\":\"Text\",\"value\":\"标签测试\"}]}]}]"},
 }
 
 func TestJSONRenderer(t *testing.T) {
@@ -63,9 +62,8 @@ func TestJSONRenderer(t *testing.T) {
 
 	for _, test := range JSONRendererTests {
 		jsonStr := luteEngine.RenderJSON(test.from)
-		fmt.Println(jsonStr)
-	//	if test.to != jsonStr {
-	//		t.Fatalf("test case [%s] failed\nexpected\n\t%q\ngot\n\t%q\noriginal markdown text\n\t%q", test.name, test.to, jsonStr, test.from)
-	//	}
+		if test.to != jsonStr {
+			t.Fatalf("test case [%s] failed\nexpected\n\t%q\ngot\n\t%q\noriginal markdown text\n\t%q", test.name, test.to, jsonStr, test.from)
+		}
 	}
 }

--- a/test/json_renderer_test.go
+++ b/test/json_renderer_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/88250/lute"
 )
 
-var JSONRendererTest = "**`小小的文本测试`**"
+var JSONRendererTest = "- 测试1\n- 测试2\n- 测试3\n"
 
 func TestJSONRenderer(t *testing.T) {
 	luteEngine := lute.New()

--- a/test/json_renderer_test.go
+++ b/test/json_renderer_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/88250/lute"
 )
 
-var JSONRendererTest = "| 表头 | 标题 |\n| --- | --- |\n| item1 | item2 |\n"
+var JSONRendererTest = "```mindmap\n- 教程\n- 语法指导\n  - 普通内容\n  - 提及用户\n  - 表情符号 Emoji\n    - 一些表情例子\n  - 大标题 - Heading 3\n    - Heading 4\n      - Heading 5\n        - Heading 6\n  - 图片\n  - 代码块\n    - 普通\n    - 语法高亮支持\n      - 演示 Go 代码高亮\n      - 演示 Java 高亮\n  - 有序、无序、任务列表\n    - 无序列表\n    - 有序列表\n    - 任务列表\n  - 表格\n  - 隐藏细节\n  - 段落\n  - 链接引用\n  - 数学公式\n  - 脑图\n  - 流程图\n  - 时序图\n  - 甘特图\n  - 图表\n  - 五线谱\n  - Graphviz\n  - 多媒体\n  - 脚注\n- 快捷键\n```\n"
 
 func TestJSONRenderer(t *testing.T) {
 	luteEngine := lute.New()

--- a/test/json_renderer_test.go
+++ b/test/json_renderer_test.go
@@ -17,12 +17,55 @@ import (
 	"github.com/88250/lute"
 )
 
-var JSONRendererTest = "```mindmap\n- 教程\n- 语法指导\n  - 普通内容\n  - 提及用户\n  - 表情符号 Emoji\n    - 一些表情例子\n  - 大标题 - Heading 3\n    - Heading 4\n      - Heading 5\n        - Heading 6\n  - 图片\n  - 代码块\n    - 普通\n    - 语法高亮支持\n      - 演示 Go 代码高亮\n      - 演示 Java 高亮\n  - 有序、无序、任务列表\n    - 无序列表\n    - 有序列表\n    - 任务列表\n  - 表格\n  - 隐藏细节\n  - 段落\n  - 链接引用\n  - 数学公式\n  - 脑图\n  - 流程图\n  - 时序图\n  - 甘特图\n  - 图表\n  - 五线谱\n  - Graphviz\n  - 多媒体\n  - 脚注\n- 快捷键\n```\n"
+var JSONRendererTests = []parseTest{
+	{"测试普通文本","普通文本测试","[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Text\",\"value\":\"普通文本测试\"}]}]"},
+	{"测试行内代码", "`console.log(\"Hello World\")`", "[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"CodeSpan\",\"value\":\"console.log(\\\"Hello World\\\")\"}]}]\n"},
+	{"测试代码块", "```js\nconsole.log(\"Hello World\")\n```\n", "[{\"type\":\"CodeBlock\",\"value\":\"console.log(\\\"Hello World\\\")\\n\",\"language\":\"js\"}]"},
+	{"测试数学块", "$$\na + b = c\n$$\n", "[{\"type\":\"MathBlock\",\"value\":\"a + b = c\"}]"},
+	{"测试行内数学公式", "$a + b = c$", "[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"InlineMath\",\"value\":\"a + b = c\"}]}]\n"},
+	{"测试斜体", "*测试斜体*", "[{\"flag\":\"Paragraph\",\"children\":[{\"flag\":\"Emphasis\",\"children\":[{\"type\":\"Text\",\"value\":\"测试斜体\"}]}]}]\n"},
+	{"测试加粗", "**测试粗体**", "[{\"flag\":\"Paragraph\",\"children\":[{\"flag\":\"Strong\",\"children\":[{\"type\":\"Text\",\"value\":\"测试粗体\"}]}]}]\n"},
+	{"测试引用块", "> 测试引用块", "[{\"flag\":\"Blockquote\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Text\",\"value\":\"测试引用块\"}]}]}]\n"},
+	{"测试标题", "# 一级标题", "[{\"type\":\"Heading\",\"value\":\"h1\",\"children\":[{\"type\":\"Text\",\"value\":\"一级标题\"}]}]\n"},
+	{"测试无序列表", "- item1\n- item2\n- item3\n", "[{\"type\":\"List\",\"value\":\"ul\",\"children\":[{\"flag\":\"ListItem\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Text\",\"value\":\"item1\"}]}]},{\"flag\":\"ListItem\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Text\",\"value\":\"item2\"}]}]},{\"flag\":\"ListItem\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Text\",\"value\":\"item3\"}]}]}]}]\n"},
+	{"测试有序列表", "1. item1\n2. item2\n3. item3\n", "[{\"type\":\"List\",\"value\":\"ol\",\"children\":[{\"flag\":\"ListItem\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Text\",\"value\":\"item1\"}]}]},{\"flag\":\"ListItem\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Text\",\"value\":\"item2\"}]}]},{\"flag\":\"ListItem\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Text\",\"value\":\"item3\"}]}]}]}]\n"},
+	//{"测试分割线", "---", ""},
+	//{"测试软换行", "测试换行\\n", ""},
+	{"测试HTML块", "<div>\nHTML块\n</div>\n", "[{\"type\":\"HTMLBlock\",\"value\":\"<div>\\nHTML块\\n</div>\"}]\n"},
+	{"测试行内HTML", "<a>行内HTML</a>", "[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"InlineHTML\",\"value\":\"<a>\"},{\"type\":\"Text\",\"value\":\"行内HTML\"},{\"type\":\"InlineHTML\",\"value\":\"</a>\"}]}]\n"},
+	{"测试链接", "[链接文本](链接)", "[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Link\",\"value\":\"%E9%93%BE%E6%8E%A5\",\"title\":\"链接文本\"}]}]\n"},
+	{"测试图片", "![图片文本](图片链接)", "[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"Image\",\"value\":\"%E5%9B%BE%E7%89%87%E9%93%BE%E6%8E%A5\",\"title\":\"图片文本\"}]}]\n"},
+	{"测试删除线", "~~删除线~~", "[{\"flag\":\"Paragraph\",\"children\":[{\"flag\":\"Strikethrough\",\"children\":[{\"type\":\"Text\",\"value\":\"删除线\"}]}]}]\n"},
+	{"测试TaskList", "- [X] item1\n- [ ] item2\n- [X] item3\n", "[{\"type\":\"List\",\"value\":\"ul\",\"children\":[{\"flag\":\"ListItem\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"TaskListItemMarker\",\"value\":\"true\"},{\"type\":\"Text\",\"value\":\" item1\"}]}]},{\"flag\":\"ListItem\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"TaskListItemMarker\",\"value\":\"false\"},{\"type\":\"Text\",\"value\":\" item2\"}]}]},{\"flag\":\"ListItem\",\"children\":[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"TaskListItemMarker\",\"value\":\"true\"},{\"type\":\"Text\",\"value\":\" item3\"}]}]}]}]\n"},
+	{"测试表格", "| 表头 | 标题 |\n| --- | --- |\n| item1 | item2 |\n| item3 | item4 |\n", "[{\"flag\":\"Table\",\"children\":[{\"flag\":\"TableHead\",\"children\":[{\"flag\":\"TableRow\",\"children\":[{\"type\":\"TableCell\",\"value\":\"left\",\"children\":[{\"type\":\"Text\",\"value\":\"表头\"}]},{\"type\":\"TableCell\",\"value\":\"left\",\"children\":[{\"type\":\"Text\",\"value\":\"标题\"}]}]}]},{\"flag\":\"TableRow\",\"children\":[{\"type\":\"TableCell\",\"value\":\"left\",\"children\":[{\"type\":\"Text\",\"value\":\"item1\"}]},{\"type\":\"TableCell\",\"value\":\"left\",\"children\":[{\"type\":\"Text\",\"value\":\"item2\"}]}]},{\"flag\":\"TableRow\",\"children\":[{\"type\":\"TableCell\",\"value\":\"left\",\"children\":[{\"type\":\"Text\",\"value\":\"item3\"}]},{\"type\":\"TableCell\",\"value\":\"left\",\"children\":[{\"type\":\"Text\",\"value\":\"item4\"}]}]}]}]\n"},
+	{"测试emoji", ":cn:", "[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"EmojiUnicode\",\"value\":\"🇨🇳\"}]}]\n"},
+	{"测试HTML实体符号", "&copy;", "[{\"flag\":\"Paragraph\",\"children\":[{\"type\":\"HTMLEntity\",\"value\":\"©\"}]}]"},
+	{"测试yaml", "---\nyaml测试\n---\n", "[{\"type\":\"YamlFrontMatter\",\"value\":\"yaml测试\"}]"},
+	//{"测试块引用", "((id \"内容块引用\")", ""},
+	{"测试高亮", "==高亮==", "[{\"flag\":\"Paragraph\",\"children\":[{\"flag\":\"Mark\",\"children\":[{\"type\":\"Text\",\"value\":\"高亮\"}]}]}]\n"},
+	{"测试上标", "^上标^", "[{\"flag\":\"Paragraph\",\"children\":[{\"flag\":\"Sup\",\"children\":[{\"type\":\"Text\",\"value\":\"上标\"}]}]}]"},
+	{"测试下标", "~下标~", "[{\"flag\":\"Paragraph\",\"children\":[{\"flag\":\"Sub\",\"children\":[{\"type\":\"Text\",\"value\":\"下标\"}]}]}]\n"},
+	{"测试内容块查询嵌入", "!{{ SELECT * FROM blocks WHERE content LIKE '%待办%' }}", "[{\"type\":\"BlockQueryEmbed\",\"value\":\"SELECT * FROM blocks WHERE content LIKE \\'%待办%\\'\"},]\n"},
+	{"测试内容块嵌入节点", "!((id \"text\"))", "[{\"type\":\"BlockEmbed\",\"value\":\"text\"}]\n"},
+	{"测试标签", "#标签测试#", "[{\"flag\":\"Paragraph\",\"children\":[{\"flag\":\"Tag\",\"children\":[{\"type\":\"Text\",\"value\":\"标签测试\"}]}]}]\n"},
+}
 
 func TestJSONRenderer(t *testing.T) {
 	luteEngine := lute.New()
-	luteEngine.KramdownIAL = false
+	luteEngine.Sup = true
+	luteEngine.Sub = true
+	luteEngine.Mark = true
+ 	luteEngine.KramdownIAL = false
+ 	luteEngine.Footnotes = true
+ 	luteEngine.BlockRef = true
+ 	luteEngine.Tag = true
+ 	luteEngine.SoftBreak2HardBreak = true
 
-	jsonStr := luteEngine.RenderJSON(JSONRendererTest)
-	fmt.Println(jsonStr)
+	for _, test := range JSONRendererTests {
+		jsonStr := luteEngine.RenderJSON(test.from)
+		fmt.Println(jsonStr)
+	//	if test.to != jsonStr {
+	//		t.Fatalf("test case [%s] failed\nexpected\n\t%q\ngot\n\t%q\noriginal markdown text\n\t%q", test.name, test.to, jsonStr, test.from)
+	//	}
+	}
 }

--- a/test/json_renderer_test.go
+++ b/test/json_renderer_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/88250/lute"
 )
 
-var JSONRendererTest = "- 测试1\n- 测试2\n- 测试3\n"
+var JSONRendererTest = "| 表头 | 标题 |\n| --- | --- |\n| item1 | item2 |\n"
 
 func TestJSONRenderer(t *testing.T) {
 	luteEngine := lute.New()

--- a/vditor_wysiwyg.go
+++ b/vditor_wysiwyg.go
@@ -117,15 +117,6 @@ func (lute *Lute) RenderEChartsJSON(markdown string) (json string) {
 	return
 }
 
-// RenderJSON 用于渲染 JSON 格式数据
-func (lute *Lute) RenderJSON(markdown string) (json string) {
-	tree := parse.Parse("", []byte(markdown), lute.Options)
-	renderer := render.NewJSONRenderer(tree)
-	output := renderer.Render()
-	json = string(output)
-	return
-}
-
 // HTML2Md 用于将 HTML 转换为 markdown。
 func (lute *Lute) HTML2Md(html string) (markdown string) {
 	markdown, err := lute.HTML2Markdown(html)

--- a/vditor_wysiwyg.go
+++ b/vditor_wysiwyg.go
@@ -117,6 +117,15 @@ func (lute *Lute) RenderEChartsJSON(markdown string) (json string) {
 	return
 }
 
+// RenderJSON 用于渲染 JSON 格式数据
+func (lute *Lute) RenderJSON(markdown string)(json string) {
+	tree := parse.Parse("", []byte(markdown), lute.Options)
+	renderer := render.NewJSONRenderer(tree)
+	output := renderer.Render()
+	json = string(output)
+	return
+}
+
 // HTML2Md 用于将 HTML 转换为 markdown。
 func (lute *Lute) HTML2Md(html string) (markdown string) {
 	markdown, err := lute.HTML2Markdown(html)

--- a/vditor_wysiwyg.go
+++ b/vditor_wysiwyg.go
@@ -118,7 +118,7 @@ func (lute *Lute) RenderEChartsJSON(markdown string) (json string) {
 }
 
 // RenderJSON 用于渲染 JSON 格式数据
-func (lute *Lute) RenderJSON(markdown string)(json string) {
+func (lute *Lute) RenderJSON(markdown string) (json string) {
 	tree := parse.Parse("", []byte(markdown), lute.Options)
 	renderer := render.NewJSONRenderer(tree)
 	output := renderer.Render()


### PR DESCRIPTION
- 支持flag节点渲染
- 支持非flag节点渲染
- 暂不支持Karmdown语法
- 语法树生成参考`html_renderer`
- 不渲染`NodeDocument`节点
- 支持渲染的节点已经写入`README`
- 使用`lute.RenderJSON()`即可使用