### PR TITLE
:bug: 修复table格式化，中文、emoji宽度计算错误的问题

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -263,12 +263,6 @@ func (n *Node) TokenLen() (ret int) {
 	return
 }
 
-//func GetShowLen(bytes []byte) (count int) {
-//	for i:=0; i< len(bytes); {
-//
-//	}
-//}
-
 func (n *Node) NextNodeText() string {
 	if nil == n.Next {
 		return ""

--- a/ast/node.go
+++ b/ast/node.go
@@ -258,7 +258,6 @@ func (n *Node) TokenLen() (ret int) {
 			return WalkContinue
 		}
 		ret += util.BytesShowLength(n.Tokens)
-		//ret += len(n.Tokens)
 		return WalkContinue
 	})
 	return

--- a/ast/node.go
+++ b/ast/node.go
@@ -257,11 +257,18 @@ func (n *Node) TokenLen() (ret int) {
 		if !entering {
 			return WalkContinue
 		}
-		ret += len(n.Tokens)
+		ret += util.BytesShowLength(n.Tokens)
+		//ret += len(n.Tokens)
 		return WalkContinue
 	})
 	return
 }
+
+//func GetShowLen(bytes []byte) (count int) {
+//	for i:=0; i< len(bytes); {
+//
+//	}
+//}
 
 func (n *Node) NextNodeText() string {
 	if nil == n.Next {

--- a/render/format_renderer.go
+++ b/render/format_renderer.go
@@ -659,6 +659,20 @@ func (r *FormatRenderer) renderTable(node *ast.Node, entering bool) ast.WalkStat
 		for col := 0; col < len(cells[0]); col++ {
 			for row := 0; row < len(cells) && col < len(cells[row]); row++ {
 				cells[row][col].TableCellContentWidth = cells[row][col].TokenLen()
+				//自动添加空格会导致单元格宽度发生变化
+				if r.Options.AutoSpace {
+					ret := 0
+					//遍历字节点，将可能会多出来的空格计算出来
+					ast.Walk(cells[row][col], func(n *ast.Node, entering bool) ast.WalkStatus {
+						if !entering {
+							return ast.WalkContinue
+						}
+						//空格仅一个字节，可以直接计算长度
+						ret += len(r.Space(n.Tokens)) - len(n.Tokens)
+						return ast.WalkContinue
+					})
+					cells[row][col].TableCellContentWidth += ret
+				}
 				if maxWidth < cells[row][col].TableCellContentWidth {
 					maxWidth = cells[row][col].TableCellContentWidth
 				}

--- a/test/format-case7-formatted.md
+++ b/test/format-case7-formatted.md
@@ -1,0 +1,4 @@
+| n  | value               | 描述        |
+| -- | ------------------- | ----------- |
+| 😃 | 短                  | description |
+| x  | long long long long | short       |

--- a/test/format-case7-formatted.md
+++ b/test/format-case7-formatted.md
@@ -1,4 +1,4 @@
-| n  | value               | 描述        |
-| -- | ------------------- | ----------- |
-| 😃 | 短                  | description |
-| x  | long long long long | short       |
+| n    | value               | 描述        |
+| ---- | ------------------- | ----------- |
+| 😃   | 短                  | description |
+| x 短 | long long long long | short       |

--- a/test/format-case7.md
+++ b/test/format-case7.md
@@ -1,4 +1,4 @@
 |n|value|描述|
 |--|--|-|
 |😃| 短| description|
-|x|long long long long |short|
+|x短|long long long long |short|

--- a/test/format-case7.md
+++ b/test/format-case7.md
@@ -1,0 +1,4 @@
+|n|value|描述|
+|--|--|-|
+|😃| 短| description|
+|x|long long long long |short|

--- a/util/byte_str.go
+++ b/util/byte_str.go
@@ -25,3 +25,19 @@ func StrToBytes(str string) []byte {
 	h := [3]uintptr{x[0], x[1], x[1]}
 	return *(*[]byte)(unsafe.Pointer(&h))
 }
+
+// BytesShowLength 获取字节数组展示为UTF8字符串时的长度
+func BytesShowLength(bytes []byte) int {
+	length := 0
+	for i := 0; i < len(bytes); i++ {
+		//按位与 11000000 为 10000000 则表示为utf8字节首位
+		if (bytes[i] & 0xc0) != 0x80 {
+			if bytes[i] < 0x7f {
+				length++
+			} else {
+				length += 2
+			}
+		}
+	}
+	return length
+}


### PR DESCRIPTION
修复table format在中文场景下格式化不正确的问题。
目前是按照字节计算宽度，修复后，按照utf8编码处理。

* 如果是1个字节的字符，则认为是半角，占用一个宽度
* 如果是1个以上字节的字符，则认为是全，占用两个宽度

问题：这样处理还是有点问题，
1. 是否是只能用UTF8编码
2. 无法准确的确定哪些是全角，哪些是半角，事实上还有拉丁文之类的是半角字符，我这里也没有处理