### PR TITLE
:bug: <a> 中嵌套 <img> 时，整个 <a> 被过滤

### DIFF
--- a/test/v2m_test.go
+++ b/test/v2m_test.go
@@ -18,6 +18,8 @@ import (
 
 var vditorDOM2MdTests = []parseTest{
 
+	{"117", "<a><img></a>", "[![]()]()\n"},
+	{"116", "<a href=\"https://example.com\"><img src=\"https://example.org\" alt=\"example\" title=\"example\"></a>", "[![example](https://example.org \"example\")](https://example.com)\n"},
 	{"115", "<ul><li><img src=\"xxx.png\"></li></ul>", "* ![](xxx.png)\n"},
 	{"114", "<p data-block=\"0\"><span class=\"vditor-comment vditor-comment--focus\" data-cmtids=\"20201105103606-fpmdc18\">foo<wbr></span></p>", "<span class=\"vditor-comment vditor-comment--focus\" data-cmtids=\"20201105103606-fpmdc18\">foo</span>\n"},
 	{"113", "<div data-block=\"0\" data-type=\"footnotes-block\"><p><wbr><br></p></div>", "\n"},

--- a/vditor_wysiwyg.go
+++ b/vditor_wysiwyg.go
@@ -989,9 +989,11 @@ func (lute *Lute) genASTByVditorDOM(n *html.Node, tree *parse.Tree) {
 		tree.Context.Tip = node
 		defer tree.Context.ParentTip()
 	case atom.A:
-		text := lute.domText(n)
-		if "" == text || parse.Zwsp == text {
-			return
+		if n.FirstChild == nil || n.FirstChild.Type == html.TextNode {
+			text := lute.domText(n)
+			if "" == text || parse.Zwsp == text {
+				return
+			}
 		}
 
 		node.Type = ast.NodeLink


### PR DESCRIPTION
fix https://github.com/88250/lute/issues/156