### PR TITLE
测试用例 https://github.com/88250/lute/issues/185

### DIFF
--- a/test/term_typo_test.go
+++ b/test/term_typo_test.go
@@ -50,7 +50,7 @@ func TestTermTypoFormat(t *testing.T) {
 	luteEngine := lute.New()
 	luteEngine.SetAutoSpace(true)
 	luteEngine.SetFixTermTypo(true)
-	luteEngine.PutTerms(map[string]string{"customtest": "CUSTOMtest"})
+	// luteEngine.PutTerms(map[string]string{"customtest": "CUSTOMtest"})
 	for _, test := range termTypoFormatTests {
 		html := luteEngine.FormatStr(test.name, test.from)
 		if test.to != html {


### PR DESCRIPTION
发现问题出在这行代码上：
```
luteEngine.PutTerms(map[string]string{"customtest": "CUSTOMtest"})
```

注释掉后测试不通过。