### PR TITLE
🐛 fix: When vditor inserts HTML, linkBase does not take effect

### DIFF
--- a/render/vditor_ir_renderer.go
+++ b/render/vditor_ir_renderer.go
@@ -998,6 +998,7 @@ func (r *VditorIRRenderer) renderHTML(node *ast.Node, entering bool) ast.WalkSta
 		if r.Options.Sanitize {
 			tokens = sanitize(tokens)
 		}
+		tokens = r.tagSrcPath(tokens)
 		r.Write(tokens)
 		r.WriteString("</pre></div>")
 	}

--- a/render/vditor_wysiwyg_renderer.go
+++ b/render/vditor_wysiwyg_renderer.go
@@ -796,6 +796,7 @@ func (r *VditorRenderer) renderHTML(node *ast.Node, entering bool) ast.WalkStatu
 	if r.Options.Sanitize {
 		tokens = sanitize(tokens)
 	}
+	tokens = r.tagSrcPath(tokens)
 	r.Write(tokens)
 	r.WriteString("</pre></div>")
 	return ast.WalkContinue


### PR DESCRIPTION
https://github.com/88250/lute/issues/213