### PR TITLE
Add infographic to languagesNoHighlight

### DIFF
--- a/render/renderer.go
+++ b/render/renderer.go
@@ -715,7 +715,7 @@ func (r *BaseRenderer) NodeAttrsStr(node *ast.Node) (ret string) {
 }
 
 // languagesNoHighlight 中定义的语言不要进行代码语法高亮。这些代码块会在前端进行渲染，比如各种图表。
-var languagesNoHighlight = []string{"mermaid", "echarts", "abc", "graphviz", "mindmap", "flowchart", "plantuml"}
+var languagesNoHighlight = []string{"mermaid", "echarts", "abc", "graphviz", "mindmap", "flowchart", "plantuml", "infographic"}
 
 func NoHighlight(language string) bool {
 	if "" == language {

--- a/test/format-case4-formatted.md
+++ b/test/format-case4-formatted.md
@@ -263,6 +263,40 @@ K: Em
 "G"g2ab3|"Em"gfe"D"f2d|"Em"e3-e3:|
 ```
 
+### 信息图
+
+```infographic
+infographic list-row-horizontal-icon-arrow
+data
+  title 互联网技术演进史
+  desc 从Web 1.0到AI时代的关键里程碑
+  items
+    - time 1991
+      label 万维网诞生
+      desc Tim Berners-Lee发布首个网站，开启互联网时代
+      icon web
+    - time 2004
+      label Web 2.0兴起
+      desc 社交媒体和用户生成内容成为主流
+      icon account-multiple
+    - time 2007
+      label 移动互联网
+      desc iPhone发布，智能手机改变世界
+      icon cellphone
+    - time 2015
+      label 云原生时代
+      desc 容器化和微服务架构广泛应用
+      icon cloud
+    - time 2020
+      label 低代码平台
+      desc 可视化开发降低技术门槛
+      icon application-brackets
+    - time 2023
+      label AI大模型
+      desc ChatGPT引爆生成式AI革命
+      icon brain
+```
+
 ## 快捷键
 
 我们的编辑器支持很多快捷键，具体请参考 [键盘快捷键](https://ld246.com/article/1474030007391)（或者按 "`?` ":smirk_cat:）

--- a/test/format-case4.md
+++ b/test/format-case4.md
@@ -263,6 +263,40 @@ K: Em
 "G"g2ab3|"Em"gfe"D"f2d|"Em"e3-e3:|
 ```
 
+### 信息图
+
+```infographic
+infographic list-row-horizontal-icon-arrow
+data
+  title 互联网技术演进史
+  desc 从Web 1.0到AI时代的关键里程碑
+  items
+    - time 1991
+      label 万维网诞生
+      desc Tim Berners-Lee发布首个网站，开启互联网时代
+      icon web
+    - time 2004
+      label Web 2.0兴起
+      desc 社交媒体和用户生成内容成为主流
+      icon account-multiple
+    - time 2007
+      label 移动互联网
+      desc iPhone发布，智能手机改变世界
+      icon cellphone
+    - time 2015
+      label 云原生时代
+      desc 容器化和微服务架构广泛应用
+      icon cloud
+    - time 2020
+      label 低代码平台
+      desc 可视化开发降低技术门槛
+      icon application-brackets
+    - time 2023
+      label AI大模型
+      desc ChatGPT引爆生成式AI革命
+      icon brain
+```
+
 ## 快捷键
 
 我们的编辑器支持很多快捷键，具体请参考 [键盘快捷键](https://ld246.com/article/1474030007391)（或者按 "`?` ":smirk_cat:）


### PR DESCRIPTION
`languagesNoHighlight` 新增 `infographic`。

我正在为 `vditor` 贡献代码，接入 [AntV Infographic](https://github.com/antvis/infographic)，以支持在 Markdown 文档中渲染信息图。

不过我本地并没有配置 go 环境，因此 `lute.min.js` 需要帮忙生成一下。

<img width="795" height="727" alt="image" src="https://github.com/user-attachments/assets/bbfe9cd6-5685-4f60-a668-5ed95ce82d54" />
