### PR TITLE
Add IsValidTaskListItemMarker helper on Options

### DIFF
--- a/parse/list.go
+++ b/parse/list.go
@@ -255,7 +255,7 @@ func (t *Tree) parseListMarker(container *ast.Node) (data *ast.ListData, ial [][
 		if 3 <= len(tokens) { // 至少需要 [ ] 或者 [x] 3 个字符
 			if lex.ItemOpenBracket == tokens[0] && lex.ItemCloseBracket != tokens[1] && lex.ItemCloseBracket == tokens[2] {
 				marker := tokens[1]
-				if t.Context.ParseOption.ArbitraryTaskListItemMarker || ' ' == marker || 'x' == marker || 'X' == marker {
+				if t.Context.ParseOption.IsValidTaskListItemMarker(marker) {
 					data.Typ = 3
 					data.Checked = marker != ' '
 				}

--- a/parse/paragraph.go
+++ b/parse/paragraph.go
@@ -97,7 +97,7 @@ func paragraphFinalize(p *ast.Node, context *Context) (insertTable bool) {
 							}
 						}
 						marker := tokens[1]
-						if context.ParseOption.ArbitraryTaskListItemMarker || ' ' == marker || 'x' == marker || 'X' == marker {
+						if context.ParseOption.IsValidTaskListItemMarker(marker) {
 							taskListItemMarker := &ast.Node{Type: ast.NodeTaskListItemMarker, Tokens: tokens[:3]}
 							taskListItemMarker.ReviveFromMarker(marker)
 							if context.ParseOption.ProtyleWYSIWYG {

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -436,6 +436,12 @@ type Options struct {
 	ArbitraryTaskListItemMarker bool
 }
 
+// IsValidTaskListItemMarker 判断 marker 是否是合法的任务列表项标记符。
+// 当 ArbitraryTaskListItemMarker 开启时接受任意非 ] 字符，否则仅接受 ' '、'x' 和 'X'。
+func (options *Options) IsValidTaskListItemMarker(marker byte) bool {
+	return options.ArbitraryTaskListItemMarker || ' ' == marker || 'x' == marker || 'X' == marker
+}
+
 var EmojiLock = sync.Mutex{}
 
 func NewOptions() *Options {


### PR DESCRIPTION
Extract the duplicated marker validation logic into Options.IsValidTaskListItemMarker() method, replacing inline checks in both list.go and paragraph.go.

<!--

* PR 请提交到 dev 开发分支上

-->