### PR TITLE
Preserve IAL attribute order during merge

### DIFF
--- a/parse/inline_attribute_list.go
+++ b/parse/inline_attribute_list.go
@@ -131,12 +131,6 @@ func IAL2MapUnEsc(ial [][]string) (ret map[string]string) {
 	return
 }
 
-func setIALAttrs(node *ast.Node, ial [][]string) {
-	for _, kv := range ial {
-		node.SetIALAttr(kv[0], html.UnescapeAttrVal(kv[1]))
-	}
-}
-
 // mergeIALPreservingOrder 保持属性顺序合并 IAL，语义上等同于 IAL2Map+Map2IAL，
 // 但不会因为 map 无序导致输出属性顺序漂移。
 func mergeIALPreservingOrder(dst, src [][]string) (ret [][]string) {

--- a/parse/inline_attribute_list.go
+++ b/parse/inline_attribute_list.go
@@ -140,25 +140,25 @@ func setIALAttrs(node *ast.Node, ial [][]string) {
 // mergeIALPreservingOrder 保持属性顺序合并 IAL，语义上等同于 IAL2Map+Map2IAL，
 // 但不会因为 map 无序导致输出属性顺序漂移。
 func mergeIALPreservingOrder(dst, src [][]string) (ret [][]string) {
-	ret = make([][]string, 0, len(dst)+len(src))
-	for _, kv := range dst {
-		ret = append(ret, []string{kv[0], html.UnescapeAttrVal(kv[1])})
+	ret = make([][]string, len(dst), len(dst)+len(src))
+	indexByName := make(map[string]int, len(dst)+len(src))
+	for i, kv := range dst {
+		ret[i] = []string{kv[0], html.UnescapeAttrVal(kv[1])}
+		if _, exists := indexByName[kv[0]]; !exists {
+			indexByName[kv[0]] = i
+		}
 	}
 
 	for _, kv := range src {
 		name := kv[0]
 		value := html.UnescapeAttrVal(kv[1])
-		updated := false
-		for _, existing := range ret {
-			if existing[0] == name {
-				existing[1] = value
-				updated = true
-				break
-			}
+		if idx, exists := indexByName[name]; exists {
+			ret[idx][1] = value
+			continue
 		}
-		if !updated {
-			ret = append(ret, []string{name, value})
-		}
+
+		indexByName[name] = len(ret)
+		ret = append(ret, []string{name, value})
 	}
 	return
 }

--- a/parse/inline_attribute_list.go
+++ b/parse/inline_attribute_list.go
@@ -132,15 +132,20 @@ func IAL2MapUnEsc(ial [][]string) (ret map[string]string) {
 }
 
 // mergeIALPreservingOrder 保持属性顺序合并 IAL，语义上等同于 IAL2Map+Map2IAL，
-// 但不会因为 map 无序导致输出属性顺序漂移。
+// 但不会因为 map 无序导致输出属性顺序漂移。重复 key 会被折叠，最后一个值生效。
 func mergeIALPreservingOrder(dst, src [][]string) (ret [][]string) {
-	ret = make([][]string, len(dst), len(dst)+len(src))
+	ret = make([][]string, 0, len(dst)+len(src))
 	indexByName := make(map[string]int, len(dst)+len(src))
-	for i, kv := range dst {
-		ret[i] = []string{kv[0], html.UnescapeAttrVal(kv[1])}
-		if _, exists := indexByName[kv[0]]; !exists {
-			indexByName[kv[0]] = i
+	for _, kv := range dst {
+		name := kv[0]
+		value := html.UnescapeAttrVal(kv[1])
+		if idx, exists := indexByName[name]; exists {
+			ret[idx][1] = value
+			continue
 		}
+
+		indexByName[name] = len(ret)
+		ret = append(ret, []string{name, value})
 	}
 
 	for _, kv := range src {

--- a/parse/inline_attribute_list.go
+++ b/parse/inline_attribute_list.go
@@ -131,6 +131,38 @@ func IAL2MapUnEsc(ial [][]string) (ret map[string]string) {
 	return
 }
 
+func setIALAttrs(node *ast.Node, ial [][]string) {
+	for _, kv := range ial {
+		node.SetIALAttr(kv[0], html.UnescapeAttrVal(kv[1]))
+	}
+}
+
+// mergeIALPreservingOrder 保持属性顺序合并 IAL，语义上等同于 IAL2Map+Map2IAL，
+// 但不会因为 map 无序导致输出属性顺序漂移。
+func mergeIALPreservingOrder(dst, src [][]string) (ret [][]string) {
+	ret = make([][]string, 0, len(dst)+len(src))
+	for _, kv := range dst {
+		ret = append(ret, []string{kv[0], html.UnescapeAttrVal(kv[1])})
+	}
+
+	for _, kv := range src {
+		name := kv[0]
+		value := html.UnescapeAttrVal(kv[1])
+		updated := false
+		for _, existing := range ret {
+			if existing[0] == name {
+				existing[1] = value
+				updated = true
+				break
+			}
+		}
+		if !updated {
+			ret = append(ret, []string{name, value})
+		}
+	}
+	return
+}
+
 func Map2IAL(properties map[string]string) (ret [][]string) {
 	ret = [][]string{}
 	for k, v := range properties {

--- a/parse/inline_attribute_list_test.go
+++ b/parse/inline_attribute_list_test.go
@@ -26,6 +26,14 @@ func TestMergeIALPreservingOrder(t *testing.T) {
 			src:  [][]string{{"custom-b", "info"}},
 			want: [][]string{{"data-node-id", "20250824233004-3qfd5gf"}, {"data-node-index", "1"}, {"data-type", "NodeBlockquote"}, {"class", "bq"}, {"updated", "20250824233509"}, {"custom-b", "info"}},
 		},
+		{
+			// 与旧逻辑的 map 语义对齐：重复 key 需要折叠，最后一个值生效，
+			// 但输出顺序保持稳定，不再随机漂移。
+			name: "collapses_duplicate_attrs_with_stable_order",
+			dst:  [][]string{{"id", "old"}, {"id", "shadow"}, {"class", "foo"}},
+			src:  [][]string{{"class", "bar"}, {"id", "new"}},
+			want: [][]string{{"id", "new"}, {"class", "bar"}},
+		},
 	}
 
 	for _, tt := range tests {

--- a/parse/inline_attribute_list_test.go
+++ b/parse/inline_attribute_list_test.go
@@ -1,0 +1,39 @@
+package parse
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeIALPreservingOrder(t *testing.T) {
+	tests := []struct {
+		name string
+		dst  [][]string
+		src  [][]string
+		want [][]string
+	}{
+		{
+			// 覆盖已有属性但不改变其位置；新增属性按 src 顺序追加，值会先做反转义。
+			name: "updates_existing_attrs_and_appends_new_attrs",
+			dst:  [][]string{{"id", "old"}, {"class", "foo&amp;bar"}},
+			src:  [][]string{{"id", "new"}, {"updated", "20260405"}, {"title", "a&amp;b"}},
+			want: [][]string{{"id", "new"}, {"class", "foo&bar"}, {"updated", "20260405"}, {"title", "a&b"}},
+		},
+		{
+			// 锁定当前兼容行为：dst 中若已有重复 key，只更新第一次出现的位置。
+			name: "updates_only_first_duplicate_key_in_dst",
+			dst:  [][]string{{"id", "old"}, {"id", "shadow"}, {"class", "foo"}},
+			src:  [][]string{{"id", "new"}, {"class", "bar"}},
+			want: [][]string{{"id", "new"}, {"id", "shadow"}, {"class", "bar"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeIALPreservingOrder(tt.dst, tt.src)
+			if !reflect.DeepEqual(tt.want, got) {
+				t.Fatalf("unexpected merged ial, want %v, got %v", tt.want, got)
+			}
+		})
+	}
+}

--- a/parse/inline_attribute_list_test.go
+++ b/parse/inline_attribute_list_test.go
@@ -20,11 +20,11 @@ func TestMergeIALPreservingOrder(t *testing.T) {
 			want: [][]string{{"id", "new"}, {"class", "foo&bar"}, {"updated", "20260405"}, {"title", "a&b"}},
 		},
 		{
-			// 锁定当前兼容行为：dst 中若已有重复 key，只更新第一次出现的位置。
-			name: "updates_only_first_duplicate_key_in_dst",
-			dst:  [][]string{{"id", "old"}, {"id", "shadow"}, {"class", "foo"}},
-			src:  [][]string{{"id", "new"}, {"class", "bar"}},
-			want: [][]string{{"id", "new"}, {"id", "shadow"}, {"class", "bar"}},
+			// 对应 SpinBlockDOM case 262：已有块级属性顺序保持不变，新的 IAL 属性只能追加到末尾。
+			name: "appends_new_attr_after_existing_block_attrs",
+			dst:  [][]string{{"data-node-id", "20250824233004-3qfd5gf"}, {"data-node-index", "1"}, {"data-type", "NodeBlockquote"}, {"class", "bq"}, {"updated", "20250824233509"}},
+			src:  [][]string{{"custom-b", "info"}},
+			want: [][]string{{"data-node-id", "20250824233004-3qfd5gf"}, {"data-node-index", "1"}, {"data-type", "NodeBlockquote"}, {"class", "bq"}, {"updated", "20250824233509"}, {"custom-b", "info"}},
 		},
 	}
 

--- a/parse/inlines.go
+++ b/parse/inlines.go
@@ -10,7 +10,10 @@
 
 package parse
 
-import "github.com/88250/lute/ast"
+import (
+	"github.com/88250/lute/ast"
+	"github.com/88250/lute/html"
+)
 
 // parseInlines 解析并生成行级节点。
 func (t *Tree) parseInlines() {
@@ -56,7 +59,9 @@ func (t *Tree) walkParseInline(node *ast.Node) {
 			} else if ial := t.Context.parseKramdownIALInListItem(tokens); 0 < len(ial) {
 				if nil != node.Previous {
 					// 解析 kramdown 列表或者引述块时可能出现标记符后为空（* \n{id:foo} 或者 >\n{: custom-b="info" }），此时 IAL 应该进行合并
-					setIALAttrs(node.Previous, ial)
+					for _, kv := range ial {
+						node.Previous.SetIALAttr(kv[0], html.UnescapeAttrVal(kv[1]))
+					}
 					next := node.Next
 					node.Unlink()
 					node.Next = next

--- a/parse/inlines.go
+++ b/parse/inlines.go
@@ -10,9 +10,7 @@
 
 package parse
 
-import (
-	"github.com/88250/lute/ast"
-)
+import "github.com/88250/lute/ast"
 
 // parseInlines 解析并生成行级节点。
 func (t *Tree) parseInlines() {
@@ -58,19 +56,12 @@ func (t *Tree) walkParseInline(node *ast.Node) {
 			} else if ial := t.Context.parseKramdownIALInListItem(tokens); 0 < len(ial) {
 				if nil != node.Previous {
 					// 解析 kramdown 列表或者引述块时可能出现标记符后为空（* \n{id:foo} 或者 >\n{: custom-b="info" }），此时 IAL 应该进行合并
-					m := IAL2Map(ial)
-					for k, v := range m {
-						node.Previous.SetIALAttr(k, v)
-					}
+					setIALAttrs(node.Previous, ial)
 					next := node.Next
 					node.Unlink()
 					node.Next = next
 					if nil != node.Next && ast.NodeKramdownBlockIAL == node.Next.Type {
-						mergeMap := IAL2Map(Tokens2IAL(node.Next.Tokens))
-						for k, v := range m {
-							mergeMap[k] = v
-						}
-						node.Next.Tokens = IAL2Tokens(Map2IAL(mergeMap))
+						node.Next.Tokens = IAL2Tokens(mergeIALPreservingOrder(Tokens2IAL(node.Next.Tokens), ial))
 					}
 					return
 				}


### PR DESCRIPTION
现在有一个测试用例比较不稳定：https://github.com/88250/lute/actions/runs/23746340520/job/69175884890
```
    spin_block_test.go:329: test case [262] failed
        expected
        	"<div data-node-id=\"20250824233004-3qfd5gf\" data-node-index=\"1\" data-type=\"NodeBlockquote\" class=\"bq\" updated=\"20250824233509\" custom-b=\"info\"><div data-node-id=\"20060102150405-1a2b3c4\" data-type=\"NodeParagraph\" class=\"p\" updated=\"20060102150405\"><div contenteditable=\"true\" spellcheck=\"false\"><wbr></div><div class=\"protyle-attr\" contenteditable=\"false\">\u200b</div></div><div class=\"protyle-attr\" contenteditable=\"false\">\u200b</div></div>"
        got
        	"<div data-node-id=\"20250824233004-3qfd5gf\" data-node-index=\"1\" data-type=\"NodeBlockquote\" class=\"bq\" custom-b=\"info\" updated=\"20250824233509\"><div data-node-id=\"20060102150405-1a2b3c4\" data-type=\"NodeParagraph\" class=\"p\" updated=\"20060102150405\"><div contenteditable=\"true\" spellcheck=\"false\"><wbr></div><div class=\"protyle-attr\" contenteditable=\"false\">\u200b</div></div><div class=\"protyle-attr\" contenteditable=\"false\">\u200b</div></div>"
        original html
        	"<div data-node-id=\"20250824233004-3qfd5gf\" data-type=\"NodeParagraph\" class=\"p\" updated=\"20250824233509\"><div contenteditable=\"true\" spellcheck=\"false\">&gt;\n{: custom-b=\"info\" }<wbr></div><div class=\"protyle-attr\" contenteditable=\"false\">\u200b</div></div>"
```

主要是这个属性的顺序偶现会变：
- updated=\"20250824233509\" custom-b=\"info\"
- custom-b=\"info\" updated=\"20250824233509\"

<img width="804" height="240" alt="CleanShot 2026-04-06 at 01 19 08@2x" src="https://github.com/user-attachments/assets/a8cfe102-0c21-4cd9-afb7-3a540eb3330a" />
<img width="3042" height="670" alt="CleanShot 2026-04-06 at 01 19 02@2x" src="https://github.com/user-attachments/assets/64d221ad-3872-4fdf-8fbf-529695e98931" />
<img width="1406" height="262" alt="CleanShot 2026-04-06 at 01 20 51@2x" src="https://github.com/user-attachments/assets/81033a66-fdc0-49fa-9c93-82664d39d314" />
